### PR TITLE
update dump tool to use go-tgz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /reports/
 /rhmap-dumps/
+.idea

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
@@ -98,11 +99,11 @@ func TestResourceDefinitions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		var stdout, stderr bytes.Buffer
-		outFor := func(project, resource string) (io.Writer, error) {
-			return &stdout, nil
+		outFor := func(project, resource string) (io.Writer, io.Closer, error) {
+			return &stdout, ioutil.NopCloser(nil), nil
 		}
-		errOutFor := func(project, resource string) (io.Writer, error) {
-			return &stderr, nil
+		errOutFor := func(project, resource string) (io.Writer, io.Closer, error) {
+			return &stderr, ioutil.NopCloser(nil), nil
 		}
 		task := resourceDefinitions(cmdFactory, "test-project", []string{"svc", "pod", "dc"}, outFor, errOutFor)
 

--- a/tgz.go
+++ b/tgz.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"time"
+)
+
+type Archive struct {
+	tgzFile   io.Writer
+	tarWriter *tar.Writer
+	gzWriter  *gzip.Writer
+}
+
+type ArchiveWriter struct {
+	File    string
+	Archive *Archive
+	Writer  *bytes.Buffer
+}
+
+func (a *ArchiveWriter) Write(p []byte) (n int, err error) {
+	return a.Writer.Write(p)
+}
+
+func (a *ArchiveWriter) Close() error {
+	return a.Archive.AddFileByContent(a.Writer.Bytes(), a.File)
+}
+
+func NewTgz(file io.Writer) (*Archive, error) {
+	tgz := Archive{}
+	var err error
+	tgz.tgzFile = file
+	if err != nil {
+		return nil, err
+	}
+
+	tgz.gzWriter = gzip.NewWriter(tgz.tgzFile)
+	tgz.tarWriter = tar.NewWriter(tgz.gzWriter)
+
+	return &tgz, nil
+}
+
+func (a *Archive) GetWriterToFile(file string) io.WriteCloser {
+	writer := ArchiveWriter{File: file, Archive: a, Writer: &bytes.Buffer{}}
+	return &writer
+}
+
+func (a *Archive) AddFileByContent(src []byte, dest string) error {
+	header := &tar.Header{
+		Name:    dest,
+		Size:    int64(len(src)),
+		Mode:    0775,
+		ModTime: time.Now(),
+	}
+
+	if err := a.tarWriter.WriteHeader(header); err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(a.tarWriter, bytes.NewReader(src)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *Archive) Close() {
+	a.tarWriter.Close()
+	a.gzWriter.Close()
+}

--- a/tgz_test.go
+++ b/tgz_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+)
+
+func TestWritingAFile(t *testing.T) {
+	b := bytes.Buffer{}
+	tgzFile := bufio.NewReadWriter(bufio.NewReader(&b), bufio.NewWriter(&b))
+
+	tgz, err := NewTgz(tgzFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writer := tgz.GetWriterToFile("test1.txt")
+	writer.Write([]byte("test"))
+	writer.Close()
+	tgz.Close()
+	tgzFile.Flush()
+
+	files, err := decompressAndListFiles(tgzFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := files["test1.txt"]; !ok {
+		t.Fatal("Expected tgz to contain test1.txt but it didnt")
+	}
+}
+
+func decompressAndListFiles(tgzFile io.Reader) (map[string]string, error) {
+	ret := map[string]string{}
+
+	gzf, err := gzip.NewReader(tgzFile)
+	if err != nil {
+		return nil, err
+	}
+	tarReader := tar.NewReader(gzf)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		ret[header.Name] = header.Name
+	}
+
+	return ret, nil
+}


### PR DESCRIPTION
Use [go-tgz](http://github.com/philbrookes/go-tgz) to build tar.gz file.

Updated tests
