### PR TITLE
RHMAP-8114 add nagiosData dump task

### DIFF
--- a/logs.go
+++ b/logs.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os/exec"
 	"strconv"
+	"strings"
 )
 
 // LoggableResource describes an OpenShift resource that produces logs.
@@ -89,6 +90,25 @@ func getLoggableResources(getPodContainers func(string, string) ([]string, error
 			})
 	}
 	return loggableResources, nil
+}
+
+// getResourceNamesBySubstr returns a list of names for the provided resource type that contain
+// the provided string, in the provided project.
+func getResourceNamesBySubstr(project, resource, substr string) ([]string, error) {
+	resources, err := GetResourceNames(project, resource)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := resources[:0]
+
+	for _, resource := range resources {
+		if strings.Contains(resource, substr) {
+			filtered = append(filtered, resource)
+		}
+	}
+
+	return filtered, nil
 }
 
 // GetPodContainers returns a list of container names for the named pod in the

--- a/nagios.go
+++ b/nagios.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// GetNagiosStatusData is a task factory for tasks that fetch a JSON representation of
+// the provided project. The task uses outFor and errOutFor to get io.Writers
+// to write, respectively, the JSON output and any eventual error message.
+func GetNagiosStatusData(project, pod string, outFor, errOutFor projectResourceWriterCloserFactory) Task {
+	return retrieveNagiosData(func() *exec.Cmd {
+		return exec.Command("oc", "exec", pod, "--", "cat", "/var/log/nagios/status.dat")
+	}, project, pod, "status", outFor, errOutFor)
+}
+
+// GetNagiosHistoricalData is a task factory for tasks that fetch a JSON representation of
+// the provided project. The task uses outFor and errOutFor to get io.Writers
+// to write, respectively, the JSON output and any eventual error message.
+func GetNagiosHistoricalData(project, pod string, outFor, errOutFor projectResourceWriterCloserFactory) Task {
+	return retrieveNagiosData(func() *exec.Cmd {
+		return exec.Command("oc", "exec", pod, "--", "tar", "-c", "-C", "/var/log/nagios", "archives")
+	}, project, pod, "history", outFor, errOutFor)
+}
+
+// A getNagiosDataCmdFactory generates commands to get the raw nagios status data
+// in the provided project from the provided pod
+type getNagiosDataCmdFactory func() *exec.Cmd
+
+// retrieveNagiosData will dump a JSON representation of the current nagios status into
+// the io.Writer returned from outFor and log any errors it encounters doing so
+// into the io.Writer returned from errOutFor.
+func retrieveNagiosData(cmdFactory getNagiosDataCmdFactory, project, pod, nagiosResourceType string, outFor, errOutFor projectResourceWriterCloserFactory) Task {
+	return func() error {
+		stdout, stdoutCloser, err := outFor(project, pod+"-"+nagiosResourceType)
+		if err != nil {
+			return err
+		}
+		defer stdoutCloser.Close()
+
+		stderr, stderrCloser, err := errOutFor(project, pod+"-"+nagiosResourceType)
+		if err != nil {
+			return err
+		}
+		defer stderrCloser.Close()
+
+		cmd := cmdFactory()
+
+		if err := runCmdCaptureOutput(cmd, stdout, stderr); err != nil {
+			fmt.Fprint(stderr, err)
+			return err
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
# Motivation
In order to successfully diagnose customer issues using the data dumped from their system the Nagios status and history wil lbe invaluable in helping us diagnose issues. This PR intends to include the nagios status data and historical data in the dump file, for every project it is available in.

# Changes
Add 2 new tasks to the dump tool - per project:
- one to dump the current status
- one to dump the historical status

