### PR TITLE
Minor improvements

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,16 +187,6 @@ func main() {
 
 	log.Println("Running tasks...")
 
-	// Avoid the creating goroutines and other controls if we're executing
-	// tasks sequentially.
-	if *maxParallelTasks == 1 {
-		for _, task := range tasks {
-			task()
-			fmt.Fprint(os.Stderr, ".")
-		}
-		return
-	}
-
 	// Run at most N tasks in parallel, and wait for all of them to
 	// complete.
 	var wg sync.WaitGroup

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ const (
 var (
 	maxParallelTasks = flag.Int("p", runtime.NumCPU(), "max number of tasks to run in parallel")
 	maxLogLines      = flag.Int("max-log-lines", defaultMaxLogLines, "max number of log lines fetched with oc logs")
-	versionCheck     = flag.Bool("version", false, "Output the current version of the system-dump-tool")
+	printVersion     = flag.Bool("version", false, "print version and exit")
 )
 
 func runCmdCaptureOutput(cmd *exec.Cmd, out, errOut io.Writer) error {
@@ -135,7 +135,7 @@ func printError(err error) {
 func main() {
 	flag.Parse()
 
-	if *versionCheck {
+	if *printVersion {
 		fmt.Println("RHMAP fh-system-dump-tool v" + version)
 		os.Exit(0)
 	}

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func main() {
 		defer os.Exit(1)
 	}
 	if len(tasks) == 0 {
-		fmt.Println("No tasks found to execute.")
+		log.Print("No tasks found to execute.")
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -175,8 +175,12 @@ func main() {
 			log.Printf("Dumped system information to: %s", basePath)
 			return
 		}
-		cmd = exec.Command("rm", "-rf", basePath)
-		cmd.Run()
+
+		// The archive was created successfully, remove basePath. The
+		// error from os.RemoveAll is intentionally ignored, since there
+		// is no useful action we can do, and we don't need to confuse
+		// the user with an error message.
+		os.RemoveAll(basePath)
 
 		log.Printf("Dumped system information to: %s", basePath+".tar.gz")
 	}()

--- a/main.go
+++ b/main.go
@@ -218,6 +218,5 @@ func main() {
 		}()
 	}
 	wg.Wait()
-
 	fmt.Fprintln(os.Stderr)
 }


### PR DESCRIPTION
Fixed a few nits:

- Usage of `rm` binary instead of the Go equivalent;
- Printing log message with `fmt.Print` instead log `log.Print`;
- Tool usage message consistency;
- Remove custom code when flag `-p 1` is passed (bug prone);


Improvement:

- Save all logs printed during tool execution as part of the dump.