### PR TITLE
output error if Nagios is missing

### DIFF
--- a/logs.go
+++ b/logs.go
@@ -36,6 +36,8 @@ func FetchPreviousLogs(resource LoggableResource, maxLines int, out, errOut io.W
 	return ocLogs(resource, maxLines, []string{"--previous"}, out, errOut)
 }
 
+type ResourceMatchFactory func(project, resource, substr string) ([]string, error)
+
 // ocLogs fetches logs from OpenShift resources using oc.
 func ocLogs(resource LoggableResource, maxLines int, extraArgs []string, out, errOut io.Writer) Task {
 	return fetchLogs(func(resource LoggableResource) *exec.Cmd {


### PR DESCRIPTION
# Motivation
The system dump tool is much more valuable when Nagios is present in the RHMAP projects. Currently if the Nagios pod is missing this is silently ignored. Now we will output a message to the user letting them know that the tool would be empowered were Nagios present.

# Changes
Check if any nagios pods were discovered, if none were found output a message to the user.