### PR TITLE
Rhmap 9066

### DIFF
--- a/dump_writers.go
+++ b/dump_writers.go
@@ -10,12 +10,34 @@ import (
 // particular resource type within a project.
 type projectResourceWriterCloserFactory func(project, resource string) (io.Writer, io.Closer, error)
 
-// outToFile returns a function that creates an io.Writer that writes to a file
+// A platformResourceWriterFactory generates io.Writers for dumping data of a
+// particular resource type.
+type platformResourceWriterCloserFactory func(resource string) (io.Writer, io.Closer, error)
+
+// outToFileForProject returns a function that creates an io.Writer that writes to a file
 // in basepath with extension, given a project and resource. The scope can be passed as a value to group the
 // files under, or assigned an empty value to have the files grouped directly under the project.
-func outToFile(basepath, extension, scope string) projectResourceWriterCloserFactory {
+func outToFileForProject(basepath, extension, scope string) projectResourceWriterCloserFactory {
 	return func(project, resource string) (io.Writer, io.Closer, error) {
 		scopePath := filepath.Join(basepath, "projects", project, scope)
+		err := os.MkdirAll(scopePath, 0770)
+		if err != nil {
+			return nil, nil, err
+		}
+		f, err := os.Create(filepath.Join(scopePath, resource+"."+extension))
+		if err != nil {
+			return nil, nil, err
+		}
+		return f, f, nil
+	}
+}
+
+// outToFileForPlatform returns a function that creates an io.Writer that writes to a file
+// in basepath with extension, given a project and resource. The scope can be passed as a value to group the
+// files under, or assigned an empty value to have the files grouped directly under the project.
+func outToFileForPlatform(basepath, extension, scope string) platformResourceWriterCloserFactory {
+	return func(resource string) (io.Writer, io.Closer, error) {
+		scopePath := filepath.Join(basepath, scope)
 		err := os.MkdirAll(scopePath, 0770)
 		if err != nil {
 			return nil, nil, err

--- a/oadm.go
+++ b/oadm.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os/exec"
+)
+
+// OadmData is a task factory for tasks that fetch the output of oc admin diagnostics.
+// The task uses outFor and errOutFor to get io.Writers to write, respectively, the
+// stdout output and stderr output.
+func OadmData(outFor, errOutFor platformResourceWriterCloserFactory) Task {
+	return oadmData(func() *exec.Cmd {
+		return exec.Command("oc", "adm", "diagnostics")
+	}, outFor, errOutFor)
+}
+
+// A getOcAdmDiagnosticsCmdFactory generates commands to get the raw oc admin diagnostics
+// data.
+type getOcAdmDiagnosticsCmdFactory func() *exec.Cmd
+
+// oadmData will dump the output of 'oc admin diagnostics' into the stdout writer any stderr
+// output is sent to the stderr writer
+func oadmData(cmdFactory getOcAdmDiagnosticsCmdFactory, outFor, errOutFor platformResourceWriterCloserFactory) Task {
+	return func() error {
+		stdOut, stdOutCloser, err := outFor("diagnostics")
+		if err != nil {
+			return err
+		}
+		defer stdOutCloser.Close()
+
+		stdErr, stdErrCloser, err := errOutFor("diagnostics")
+		if err != nil {
+			return err
+		}
+		defer stdErrCloser.Close()
+
+		cmd := cmdFactory()
+
+		if err := runCmdCaptureOutput(cmd, stdOut, stdErr); err != nil {
+			stdErr.Write([]byte(err.Error()))
+			return err
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
# Motivation
Currently the dump created by the system dump tool does not include the output from`oc adm diagnostics` this change adds the output to the dump.

# Changes
- Add a new task to run `oc adm diagnostics` on the platform and add it to a `diagnostics` folder at the root level of the dump.
- Change the `OutToFile` to `OutToFileForProject` and add a new `OutToFileForPlatform` which writes to the root directory of the dumped archive.