### PR TITLE
Change abstraction for saving output of commands

### DIFF
--- a/fakerunner_test.go
+++ b/fakerunner_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"os/exec"
+	"sync"
+)
+
+type FakeRunner struct {
+	mu    sync.Mutex
+	Calls []RunCall
+}
+
+type RunCall struct {
+	args []string
+	path string
+}
+
+func (r *FakeRunner) Run(cmd *exec.Cmd, path string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.Calls = append(r.Calls, RunCall{cmd.Args, path})
+	return nil
+}
+
+var _ Runner = (*FakeRunner)(nil)

--- a/main.go
+++ b/main.go
@@ -187,7 +187,9 @@ func main() {
 	}()
 
 	log.Print("Starting RHMAP System Dump Tool...")
-	log.Print("Running tasks...")
 
-	RunAllTasks(basePath, *concurrentTasks)
+	runner := NewDumpRunner(basePath)
+
+	log.Print("Running tasks...")
+	RunAllTasks(runner, basePath, *concurrentTasks)
 }

--- a/runner.go
+++ b/runner.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// A Runner runs commands.
+type Runner interface {
+	Run(cmd *exec.Cmd, path string) error
+}
+
+// DumpRunner is a Runner that dumps command execution output to disk.
+type DumpRunner struct {
+	dir string
+}
+
+var _ Runner = (*DumpRunner)(nil)
+
+// NewDumpRunner creates a DumpRunner.
+func NewDumpRunner(dir string) *DumpRunner {
+	return &DumpRunner{
+		dir: dir,
+	}
+}
+
+// Run runs cmd and saves the stdout to path, relative to r.dir. Stderr, if any,
+// goes to path.stderr. Parent directories are created if necessary. Path cannot
+// be empty.
+func (r *DumpRunner) Run(cmd *exec.Cmd, path string) error {
+	if path == "" {
+		return fmt.Errorf("command %q: missing path to output", strings.Join(cmd.Args, " "))
+	}
+
+	basedir := filepath.Join(r.dir, filepath.Dir(path))
+	if err := os.MkdirAll(basedir, 0770); err != nil {
+		return err
+	}
+
+	stdout, err := os.Create(filepath.Join(r.dir, path))
+	if err != nil {
+		return err
+	}
+	defer stdout.Close()
+
+	var pathStderr = path + ".stderr"
+	stderr := &lazyFileWriter{path: filepath.Join(r.dir, pathStderr)}
+	defer stderr.Close()
+
+	cmd.Stdout = io.MultiWriter(filterWriters(cmd.Stdout, stdout)...)
+	cmd.Stderr = io.MultiWriter(filterWriters(cmd.Stderr, stderr)...)
+
+	if err := cmd.Run(); err != nil {
+		var b []byte
+		if stderr.file != nil {
+			stderr.file.Seek(0, os.SEEK_SET)
+			b, _ = ioutil.ReadAll(stderr.file)
+		}
+		return fmt.Errorf("command %q: %s: %s", strings.Join(cmd.Args, " "), err, b)
+	}
+	return nil
+}
+
+// filterWriters filters out nil writers.
+func filterWriters(writers ...io.Writer) []io.Writer {
+	ws := make([]io.Writer, len(writers))
+	copy(ws, writers)
+	filtered := ws[:0]
+	for _, w := range ws {
+		if w != nil {
+			filtered = append(filtered, w)
+		}
+	}
+	return filtered
+}
+
+// lazyFileWriter is an io.WriteCloser that writes to a file, but defers file
+// creation up until the first write.
+type lazyFileWriter struct {
+	path string
+
+	once sync.Once // ensures we attempt to create file only once.
+	file *os.File
+}
+
+var _ io.WriteCloser = (*lazyFileWriter)(nil)
+
+func (w *lazyFileWriter) Write(p []byte) (n int, err error) {
+	w.once.Do(func() {
+		w.file, err = os.Create(w.path)
+	})
+	if err != nil {
+		return
+	}
+	return w.file.Write(p)
+}
+
+func (w *lazyFileWriter) Close() error {
+	if w.file == nil {
+		return nil
+	}
+	return w.file.Close()
+}

--- a/runner_test.go
+++ b/runner_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Use `go test -tree` to debug DumpRunner tests.
+var printTree = flag.Bool("tree", false, "print file tree in DumpRunner tests")
+
+func TestDumpRunner(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-dumprunner-dir-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	if *printTree {
+		defer func() { t.Log("\n" + tree(dir)) }()
+	}
+
+	// We will use dr several times to make sure it does what it should do.
+	// Each subtest begins with setting the cmd we will run.
+	dr := NewDumpRunner(dir)
+
+	// #1 -- common case, command exits with 0, output is saved to a file.
+	cmd := helperCommand("echo", "ok")
+
+	// Set cmd.Stdout to later ensure that dr.Run will write to both b and a
+	// file.
+	var b bytes.Buffer
+	cmd.Stdout = &b
+
+	// These are the files and contents we expect to see:
+	names := []string{"out"}
+	contents := []string{cmd.Args[len(cmd.Args)-1] + "\n"}
+
+	if err := dr.Run(cmd, names[len(names)-1]); err != nil {
+		t.Errorf("Run(%q) = %v, want %v", cmd.Args[3:], err, nil)
+	}
+	if err := dirHasExactFiles(dir, names, contents); err != nil {
+		t.Error(err)
+	}
+	if got, want := b.String(), contents[len(contents)-1]; got != want {
+		t.Errorf("original stdout = %q, want %q", got, want)
+	}
+
+	// #2 -- command exits with non-zero status, both stdout and stderr are
+	// saved to disk.
+	cmd = helperCommand("stderrfail")
+	// We expect the command above to fail, and dr.Run should augment the
+	// error message to include the stderr of the command.
+	wantErrMsg := "exit status 1: some stderr text"
+
+	// Set cmd.Stderr to later ensure that dr.Run will write to both b and a
+	// file.
+	b.Reset()
+	cmd.Stderr = &b
+
+	names = append(names, "out2", "out2.stderr")
+	contents = append(contents, "", "some stderr text\n")
+
+	if err := dr.Run(cmd, names[len(names)-2]); err == nil || !strings.Contains(err.Error(), wantErrMsg) {
+		t.Errorf("Run(\"stderrfail\") = %v, want %v", err, wantErrMsg)
+	}
+	if err := dirHasExactFiles(dir, names, contents); err != nil {
+		t.Error(err)
+	}
+	if got, want := b.String(), contents[len(contents)-1]; got != want {
+		t.Errorf("original stderr = %q, want %q", got, want)
+	}
+
+	// #3 -- path to output file includes subdirectories.
+	cmd = helperCommand("echo", "I can handle subdirectories")
+
+	names = append(names, filepath.Join("sub", "foo", "bar"))
+	contents = append(contents, cmd.Args[len(cmd.Args)-1]+"\n")
+
+	if err := dr.Run(cmd, names[len(names)-1]); err != nil {
+		t.Errorf("Run(%q) = %v, want %v", cmd.Args[3:], err, nil)
+	}
+	if err := dirHasExactFiles(dir, names, contents); err != nil {
+		t.Error(err)
+	}
+
+	// #4 -- path is empty returns error, nothing new written to disk.
+	cmd = helperCommand("echo", "no path")
+
+	if err := dr.Run(cmd, ""); err == nil || !strings.Contains(err.Error(), "missing path") {
+		t.Errorf("Run(%q) = %v, want %v", cmd.Args[3:], err, nil)
+	}
+	if err := dirHasExactFiles(dir, names, contents); err != nil {
+		t.Error(err)
+	}
+}
+
+func tree(dir string) string {
+	b, _ := exec.Command("tree", "-Fah", dir).CombinedOutput()
+	return string(b)
+}
+
+func dirHasExactFiles(dir string, names, contents []string) error {
+	gotNames, err := readDir(dir)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(gotNames, names) {
+		return fmt.Errorf("names = %v, want %v", gotNames, names)
+	}
+	for i, name := range names {
+		b, err := ioutil.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
+		if string(b) != contents[i] {
+			return fmt.Errorf("file %q = %q, want %q", name, b, contents[i])
+		}
+	}
+	return nil
+}
+
+func readDir(dir string) ([]string, error) {
+	fis, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(fis))
+	for _, fi := range fis {
+		if fi.IsDir() {
+			subDir := fi.Name()
+			subNames, err := readDir(filepath.Join(dir, subDir))
+			if err != nil {
+				return nil, err
+			}
+			for _, name := range subNames {
+				names = append(names, filepath.Join(subDir, name))
+			}
+			continue
+		}
+		names = append(names, fi.Name())
+	}
+	return names, nil
+}


### PR DESCRIPTION
The `outFor` and `errOutFor` abstractions are getting harder and harder to use as we add more code.
Tests were brittle, near meaningless, and we were writing a lot of boilerplate code to get things done.

This PR introduces a `DumpRunner`. It can run commands and save output to files.
It will create a "name.stderr" file with stderr from commands, if any.

It should be now easier to write tests and code.

This PR shows how the logs tasks gets refactored to use the new abstraction. Future PRs will refactor the rest, but I decided not to submit all at once to keep this minimally reviewable.

-------

https://issues.jboss.org/browse/RHMAP-9533