### PR TITLE
Change definitions and Nagios tasks to use Runner

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -1,6 +1,26 @@
 package main
 
-import "os/exec"
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ResourceDefinition is a task factory for tasks that fetch the JSON resource
+// definition for the given resource in the given project.
+func ResourceDefinition(r Runner, project, resource string) Task {
+	return func() error {
+		// NOTE: we could fetch all resources of all types in a single
+		// call to oc, by passing a comma-separated list of resource
+		// types. Instead, we call oc multiple times to send the output
+		// to different files without processing the contents of the
+		// output from oc.
+		cmd := exec.Command("oc", "-n", project, "get", resource, "-o=json")
+		fname := strings.Replace(resource, "/", "_", -1) + ".json"
+		path := filepath.Join("projects", project, "definitions", fname)
+		return r.Run(cmd, path)
+	}
+}
 
 // ResourceDefinitions is a task factory for tasks that fetch the JSON resource
 // definition for all given types in project. For each resource type, the task

--- a/nagios_test.go
+++ b/nagios_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestGetNagiosStatusData(t *testing.T) {
+	tests := []struct {
+		project string
+		pod     string
+		calls   []RunCall
+	}{
+		{
+			project: "test-project",
+			pod:     "pod",
+			calls: []RunCall{
+				{
+					[]string{"oc", "exec", "pod", "--", "cat", "/var/log/nagios/status.dat"},
+					filepath.Join("projects", "test-project", "nagios", "pod_status.dat"),
+				},
+			},
+		},
+	}
+	for i, tt := range tests {
+		runner := &FakeRunner{}
+		task := GetNagiosStatusData(runner, tt.project, tt.pod)
+		if err := task(); err != nil {
+			t.Errorf("test %d: task() = %v, want %v", i, err, nil)
+		}
+		if !reflect.DeepEqual(runner.Calls, tt.calls) {
+			t.Errorf("test %d: runner.Calls = %q, want %q", i, runner.Calls, tt.calls)
+		}
+	}
+}
+func TestGetNagiosHistoricalData(t *testing.T) {
+	tests := []struct {
+		project string
+		pod     string
+		calls   []RunCall
+	}{
+		{
+			project: "test-project",
+			pod:     "pod",
+			calls: []RunCall{
+				{
+					[]string{"oc", "exec", "pod", "--", "tar", "-c", "-C", "/var/log/nagios", "archives"},
+					filepath.Join("projects", "test-project", "nagios", "pod_history.tar"),
+				},
+			},
+		},
+	}
+	for i, tt := range tests {
+		runner := &FakeRunner{}
+		task := GetNagiosHistoricalData(runner, tt.project, tt.pod)
+		if err := task(); err != nil {
+			t.Errorf("test %d: task() = %v, want %v", i, err, nil)
+		}
+		if !reflect.DeepEqual(runner.Calls, tt.calls) {
+			t.Errorf("test %d: runner.Calls = %q, want %q", i, runner.Calls, tt.calls)
+		}
+	}
+}

--- a/nagios_test.go
+++ b/nagios_test.go
@@ -3,8 +3,21 @@ package main
 import (
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestGetNagiosTasks(t *testing.T) {
+	tasks := make(chan Task, 1)
+	runner := &FakeRunner{}
+	GetNagiosTasks(tasks, runner, nil)
+	task := <-tasks
+
+	want := "Nagios pod could not be found"
+	if err := task(); err == nil || !strings.Contains(err.Error(), want) {
+		t.Errorf("task() = %q, want substring of %q", err, want)
+	}
+}
 
 func TestGetNagiosStatusData(t *testing.T) {
 	tests := []struct {

--- a/tasks.go
+++ b/tasks.go
@@ -79,7 +79,7 @@ func GetAllTasks(runner Runner, basepath string) <-chan Task {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			GetResourceDefinitionsTasks(tasks, projects, resources, basepath)
+			GetResourceDefinitionTasks(tasks, runner, projects, resources)
 		}()
 
 		// Add tasks to fetch logs.
@@ -146,14 +146,13 @@ func GetNagiosTasks(tasks chan<- Task, projects []string, basepath string, resou
 	}
 }
 
-// GetResourceDefinitionsTasks sends tasks to fetch the definitions of all
+// GetResourceDefinitionTasks sends tasks to fetch the definitions of all
 // resources in all projects.
-// FIXME: GetResourceDefinitionsTasks should not know about basepath.
-func GetResourceDefinitionsTasks(tasks chan<- Task, projects, resources []string, basepath string) {
+func GetResourceDefinitionTasks(tasks chan<- Task, runner Runner, projects, resources []string) {
 	for _, p := range projects {
-		outFor := outToFile(basepath, "json", "definitions")
-		errOutFor := outToFile(basepath, "stderr", "definitions")
-		tasks <- ResourceDefinitions(p, resources, outFor, errOutFor)
+		for _, resource := range resources {
+			tasks <- ResourceDefinition(runner, p, resource)
+		}
 	}
 }
 


### PR DESCRIPTION
This follows up on #26, changing more parts of the code base to use a `Runner` instead of the `outFor` and `errOutFor` abstractions.

There is one missing part before we can get rid of old code: the analysis tasks. They are notably more complicated, will go as yet another follow up.

-----------
https://issues.jboss.org/browse/RHMAP-9535