### PR TITLE
add oc adm diagnostics output to dump

### DIFF
--- a/ocadm.go
+++ b/ocadm.go
@@ -1,0 +1,12 @@
+package main
+
+import "os/exec"
+
+// GetOcAdmDiagnosticsTasks sends tasks to fetch the oc adm diagnostics result.
+func GetOcAdmDiagnosticsTask(runner Runner) Task {
+	return func() error {
+		cmd := exec.Command("oc", "adm", "diagnostics")
+		path := "oc_adm_diagnostics"
+		return runner.Run(cmd, path)
+	}
+}

--- a/ocadm_test.go
+++ b/ocadm_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetOcAdmDiagnosticsTask(t *testing.T) {
+	expectedCalls := []RunCall{
+		{
+			[]string{"oc", "adm", "diagnostics"},
+			"oc_adm_diagnostics",
+		},
+	}
+
+	runner := &FakeRunner{}
+
+	task := GetOcAdmDiagnosticsTask(runner)
+
+	if err := task(); err != nil {
+		t.Errorf("task() = %v, want %v", err, nil)
+	}
+	if !reflect.DeepEqual(runner.Calls, expectedCalls) {
+		t.Errorf("runner.Calls = %q, want %q", runner.Calls, expectedCalls)
+	}
+}

--- a/tasks.go
+++ b/tasks.go
@@ -96,6 +96,12 @@ func GetAllTasks(runner Runner, basepath string) <-chan Task {
 			GetNagiosTasks(tasks, projects, basepath, getResourceNamesBySubstr)
 		}()
 
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tasks <- GetOcAdmDiagnosticsTask(runner)
+		}()
+
 		wg.Wait()
 
 		// After all other tasks are done, add analysis tasks. We want


### PR DESCRIPTION
# Motivation
Currently the dump created by the system dump tool does not include the output from`oc adm diagnostics` this change adds the output to the dump.

# Changes
- Add a new task to run `oc adm diagnostics` on the platform and add it to the root level of the dump.