### PR TITLE
Cleanup logs tasks

### DIFF
--- a/logs.go
+++ b/logs.go
@@ -25,51 +25,66 @@ type LoggableResource struct {
 
 // GetFetchLogsTasks sends tasks to fetch current and previous logs of all
 // resources in all projects.
-func GetFetchLogsTasks(tasks chan<- Task, runner Runner, projects, resources []string) {
-	loggableResources, err := GetLogabbleResources(projects, resources)
-	if err != nil {
-		tasks <- NewError(err)
-		// continue and iterate over loggableResources even if there was
-		// an error.
-	}
-	for _, r := range loggableResources {
-		// Send task to fetch current logs.
-		tasks <- FetchLogs(runner, r, *maxLogLines)
-		// Send task to fetch previous logs.
-		tasks <- FetchPreviousLogs(runner, r, *maxLogLines)
-	}
-}
-
-// GetLogabbleResources returns a list of loggable resources. It may return
-// results even in the presence of an error.
-func GetLogabbleResources(projects, resources []string) ([]LoggableResource, error) {
-	var (
-		loggableResources []LoggableResource
-		errors            errorList
-	)
+func GetFetchLogsTasks(tasks chan<- Task, runner Runner, projects, resources []string, maxLines int) {
 	for _, p := range projects {
 		for _, rtype := range resources {
-			// FIXME: take runner as argument.
-			runner := simpleRunner{}
 			names, err := GetResourceNames(runner, p, rtype)
 			if err != nil {
-				errors = append(errors, err)
+				tasks <- NewError(err)
 				continue
 			}
 			for _, name := range names {
-				resources, err := GetLoggableResources(p, rtype, name)
-				if err != nil {
-					errors = append(errors, err)
-					continue
-				}
-				loggableResources = append(loggableResources, resources...)
+				getFetchLogsTasksPerResource(tasks, runner, p, rtype, name, maxLines)
 			}
 		}
 	}
-	if len(errors) > 0 {
-		return loggableResources, errors
+}
+
+// getFetchLogsTasksPerResource sends tasks to fetch current and previous logs
+// of the named resource of type rtype in the given project. Pod resources
+// produce tasks for each container in the pod.
+func getFetchLogsTasksPerResource(tasks chan<- Task, runner Runner, project, rtype, name string, maxLines int) {
+	var (
+		containers []string
+	)
+	switch rtype {
+	case "po", "pod", "pods":
+		var err error
+		containers, err = GetPodContainers(runner, project, name)
+		if err != nil {
+			tasks <- NewError(err)
+			return
+		}
+	default:
+		// For types other than pod, we can treat them as if
+		// they had a single unnamed container, for the name
+		// doesn't matter when fetching logs.
+		containers = []string{""}
 	}
-	return loggableResources, nil
+	for _, container := range containers {
+		r := LoggableResource{
+			Project:   project,
+			Type:      rtype,
+			Name:      name,
+			Container: container,
+		}
+		// Send task to fetch current logs.
+		tasks <- FetchLogs(runner, r, maxLines)
+		// Send task to fetch previous logs.
+		tasks <- FetchPreviousLogs(runner, r, maxLines)
+	}
+}
+
+// GetPodContainers returns a list of container names for the named pod in the
+// project.
+func GetPodContainers(runner Runner, project, name string) ([]string, error) {
+	cmd := exec.Command("oc", "-n", project, "get", "pod", name, "-o=jsonpath={.spec.containers[*].name}")
+	var b bytes.Buffer
+	cmd.Stdout = &b
+	if err := runner.Run(cmd, filepath.Join("projects", project, "pods", name, "container-names")); err != nil {
+		return nil, err
+	}
+	return readSpaceSeparated(&b)
 }
 
 // FetchLogs is a task factory for tasks that fetch the logs of a
@@ -108,55 +123,4 @@ func ocLogs(r Runner, resource LoggableResource, maxLines int, extraArgs []strin
 		path := filepath.Join("projects", resource.Project, what, filename+".logs")
 		return r.Run(cmd, path)
 	}
-}
-
-// GetLoggableResources returns a list of loggable resources for the named
-// resource of type rtype in the given project. Only pods may return multiple
-// loggable resources, as many as the number of containers in the pod.
-func GetLoggableResources(project, rtype, name string) ([]LoggableResource, error) {
-	return getLoggableResources(GetPodContainers, project, rtype, name)
-}
-
-func getLoggableResources(getPodContainers func(Runner, string, string) ([]string, error), project, rtype, name string) ([]LoggableResource, error) {
-	var (
-		loggableResources []LoggableResource
-		containers        []string
-	)
-	switch rtype {
-	case "po", "pod", "pods":
-		var err error
-		// FIXME: take runner as argument.
-		runner := simpleRunner{}
-		containers, err = getPodContainers(runner, project, name)
-		if err != nil {
-			return nil, err
-		}
-	default:
-		// For types other than pod, we can treat them as if
-		// they had a single unnamed container, for the name
-		// doesn't matter when fetching logs.
-		containers = []string{""}
-	}
-	for _, container := range containers {
-		loggableResources = append(loggableResources,
-			LoggableResource{
-				Project:   project,
-				Type:      rtype,
-				Name:      name,
-				Container: container,
-			})
-	}
-	return loggableResources, nil
-}
-
-// GetPodContainers returns a list of container names for the named pod in the
-// project.
-func GetPodContainers(runner Runner, project, name string) ([]string, error) {
-	cmd := exec.Command("oc", "-n", project, "get", "pod", name, "-o=jsonpath={.spec.containers[*].name}")
-	var b bytes.Buffer
-	cmd.Stdout = &b
-	if err := runner.Run(cmd, filepath.Join("projects", project, "pods", name, "container-names")); err != nil {
-		return nil, err
-	}
-	return readSpaceSeparated(&b)
 }

--- a/logs_test.go
+++ b/logs_test.go
@@ -1,56 +1,102 @@
 package main
 
 import (
-	"path/filepath"
+	"fmt"
+	"os/exec"
 	"reflect"
+	"strings"
+	"sync"
 	"testing"
 )
 
-func TestFetchLogs(t *testing.T) {
-	tests := []struct {
-		resource LoggableResource
-		maxLines int
-		calls    []RunCall
-	}{
-		{
-			resource: LoggableResource{
-				Project:   "test-project",
-				Type:      "pod",
-				Name:      "pod-1",
-				Container: "container-1",
-			},
-			maxLines: 42,
-			calls: []RunCall{
-				{
-					[]string{"oc", "-n", "test-project", "logs", "pod/pod-1", "-c", "container-1", "--tail", "42"},
-					filepath.Join("projects", "test-project", "logs", "pod_pod-1_container-1.logs"),
-				},
-			},
-		},
-		{
-			resource: LoggableResource{
-				Project:   "another-project",
-				Type:      "",
-				Name:      "supercore",
-				Container: "web",
-			},
-			maxLines: 100,
-			calls: []RunCall{
-				{
-					[]string{"oc", "-n", "another-project", "logs", "supercore", "-c", "web", "--tail", "100"},
-					filepath.Join("projects", "another-project", "logs", "supercore_web.logs"),
-				},
-			},
-		},
+type RunFunc func(cmd *exec.Cmd, path string) error
+
+type LogsFakeRunner struct {
+	// callMap maps commands to mock functions.
+	callMap map[string]RunFunc
+
+	mu sync.Mutex
+	// Seen is a set of commands that were run.
+	Seen map[string]struct{}
+	// Unhandled stores commands that were run and not found in callMap.
+	Unhandled []string
+}
+
+func NewLogsFakeRunner(callMap map[string]RunFunc) *LogsFakeRunner {
+	return &LogsFakeRunner{
+		callMap: callMap,
+		Seen:    make(map[string]struct{}),
 	}
-	for i, tt := range tests {
-		runner := &FakeRunner{}
-		task := FetchLogs(runner, tt.resource, tt.maxLines)
+}
+
+func (r *LogsFakeRunner) Run(cmd *exec.Cmd, path string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	args := strings.Join(cmd.Args, " ")
+	r.Seen[args] = struct{}{}
+	var f RunFunc
+	for k, v := range r.callMap {
+		if strings.Contains(args, k) {
+			f = v
+		}
+	}
+	if f != nil {
+		return f(cmd, path)
+	}
+	r.Unhandled = append(r.Unhandled, args)
+	return nil
+}
+
+func TestGetFetchLogsTasks(t *testing.T) {
+	tasks := make(chan Task)
+	runner := NewLogsFakeRunner(map[string]RunFunc{
+		"get pods": func(cmd *exec.Cmd, path string) error {
+			fmt.Fprintln(cmd.Stdout, "pod-1", "pod-2")
+			return nil
+		},
+		"get pod pod-1": func(cmd *exec.Cmd, path string) error {
+			fmt.Fprintln(cmd.Stdout, "c11", "c12")
+			return nil
+		},
+		"get pod pod-2": func(cmd *exec.Cmd, path string) error {
+			fmt.Fprintln(cmd.Stdout, "c21")
+			return nil
+		},
+		"logs pods/pod-": func(cmd *exec.Cmd, path string) error {
+			return nil
+		},
+	})
+	projects := []string{"test-project"}
+	resources := []string{"pods"}
+	const maxLines = 42
+	go func() {
+		defer close(tasks)
+		GetFetchLogsTasks(tasks, runner, projects, resources, maxLines)
+	}()
+
+	i := 0
+	for task := range tasks {
+		i++
 		if err := task(); err != nil {
-			t.Errorf("test %d: task() = %v, want %v", i, err, nil)
+			t.Errorf("task %d: task() = %v, want %v", i, err, nil)
 		}
-		if !reflect.DeepEqual(runner.Calls, tt.calls) {
-			t.Errorf("test %d: runner.Calls = %q, want %q", i, runner.Calls, tt.calls)
-		}
+	}
+
+	calls := map[string]struct{}{
+		"oc -n test-project get pods -o=jsonpath={.items[*].metadata.name}":       {},
+		"oc -n test-project get pod pod-1 -o=jsonpath={.spec.containers[*].name}": {},
+		"oc -n test-project get pod pod-2 -o=jsonpath={.spec.containers[*].name}": {},
+		"oc -n test-project logs pods/pod-1 -c c11 --tail 42":                     {},
+		"oc -n test-project logs pods/pod-1 -c c11 --tail 42 --previous":          {},
+		"oc -n test-project logs pods/pod-1 -c c12 --tail 42":                     {},
+		"oc -n test-project logs pods/pod-1 -c c12 --tail 42 --previous":          {},
+		"oc -n test-project logs pods/pod-2 -c c21 --tail 42":                     {},
+		"oc -n test-project logs pods/pod-2 -c c21 --tail 42 --previous":          {},
+	}
+	if !reflect.DeepEqual(runner.Seen, calls) {
+		t.Errorf("runner.Calls = %q, want %q", runner.Seen, calls)
+	}
+	if runner.Unhandled != nil {
+		t.Logf("unhandled commands:\n%s", strings.Join(runner.Unhandled, "\n"))
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"reflect"
 	"testing"
 )
 
@@ -51,28 +50,5 @@ func TestHelperProcess(t *testing.T) {
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command %q\n", cmd)
 		os.Exit(2)
-	}
-}
-
-func TestGetSpaceSeparated(t *testing.T) {
-	tests := []struct {
-		projects []string
-		want     []string
-	}{
-		{},
-		{[]string{"foo", "bar"}, []string{"foo", "bar"}},
-		{[]string{"foo", "bar", ""}, []string{"foo", "bar"}},
-		// TODO: Add tests involving error cases.
-	}
-	for _, tt := range tests {
-		cmd := helperCommand("echo", tt.projects...)
-		got, err := getSpaceSeparated(cmd)
-		if err != nil {
-			t.Errorf("getSpaceSeparated(%v) returned non-nil error: %v", cmd.Args, err)
-			continue
-		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("getSpaceSeparated(%v) = %v, want %v", cmd.Args, got, tt.want)
-		}
 	}
 }

--- a/nagios.go
+++ b/nagios.go
@@ -53,7 +53,9 @@ func GetNagiosHistoricalData(r Runner, project, pod string) Task {
 // getResourceNamesBySubstr returns a list of names for the provided resource type that contain
 // the provided string, in the provided project.
 func getResourceNamesBySubstr(project, resource, substr string) ([]string, error) {
-	resources, err := GetResourceNames(project, resource)
+	// FIXME: take runner as argument.
+	runner := simpleRunner{}
+	resources, err := GetResourceNames(runner, project, resource)
 	if err != nil {
 		return nil, err
 	}

--- a/tasks.go
+++ b/tasks.go
@@ -75,7 +75,7 @@ func GetAllTasks(runner Runner, basepath string) <-chan Task {
 	go func() {
 		defer close(tasks)
 
-		projects, err := GetProjects()
+		projects, err := GetProjects(runner)
 		if err != nil {
 			tasks <- NewError(err)
 			return

--- a/tasks.go
+++ b/tasks.go
@@ -98,7 +98,9 @@ func GetAllTasks(runner Runner, basepath string) <-chan Task {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			GetFetchLogsTasks(tasks, runner, projects, resourcesWithLogs)
+			// FIXME: we should not be accessing a flag value
+			// (global) here, instead take maxLines as an argument.
+			GetFetchLogsTasks(tasks, runner, projects, resourcesWithLogs, *maxLogLines)
 		}()
 
 		// Add tasks to fetch Nagios data.


### PR DESCRIPTION
Make each task map to a call to 'oc logs', so that we can have more fine
grained tasks that can run concurrently.

Eventually also fixes a problem of having similarly named functions
GetLogabbleResources and GetLoggableResources, including a typo.