### PR TITLE
refactor analysis to read from dump

### DIFF
--- a/dump_writers.go
+++ b/dump_writers.go
@@ -27,3 +27,7 @@ func outToFile(basepath, extension, scope string) projectResourceWriterCloserFac
 		return f, f, nil
 	}
 }
+
+// A pathResourceWriterFactory generates io.Writers for dumping data of a
+// particular resource type within a project.
+type pathResourceWriterCloserFactory func() (io.Writer, io.Closer, error)

--- a/main.go
+++ b/main.go
@@ -188,6 +188,7 @@ func main() {
 		// error from os.RemoveAll is intentionally ignored, since there
 		// is no useful action we can do, and we don't need to confuse
 		// the user with an error message.
+
 		os.RemoveAll(basePath)
 
 		log.Printf("Dumped system information to: %s", basePath+".tar.gz")
@@ -197,6 +198,8 @@ func main() {
 
 	runner := NewDumpRunner(basePath)
 
-	log.Print("Running tasks...")
-	RunAllTasks(runner, basePath, *concurrentTasks)
+	log.Print("Running dump tasks...")
+	RunAllDumpTasks(runner, basePath, *concurrentTasks)
+	log.Print("Running analysis tasks...")
+	RunAllAnalysisTasks(runner, basePath, *concurrentTasks)
 }


### PR DESCRIPTION
This is a WIP, opening the PR to allow for feedback on current progress.

# Motivation
Analysis tasks currently pull data from the platform. This rewrite will make them run on the dumped data instead.

Analysis tasks currently could potentially run while dump tasks are still executing, this rewrite ensures that they will run after all dump tasks are completed.

# Changes
Update analysis tasks and tests to read from the dumped files

Update tasks.go to run analysis tasks  after all the dump tasks are completed.