### PR TITLE
check event log for errors, and improve tests on analysis

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -1,11 +1,9 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
-	"strings"
 )
 
 type Info struct {
@@ -17,23 +15,27 @@ type Info struct {
 }
 
 type Result struct {
-	CheckName     string `json:"checkName" yaml:"checkName"`
-	Status        int    `json:"status" yaml:"status"`
-	StatusMessage string `json:"statusMessage" yaml:"statusMessage"`
-	Info          []Info `json:"info" yaml:"info"`
+	CheckName     string  `json:"checkName" yaml:"checkName"`
+	Status        int     `json:"status" yaml:"status"`
+	StatusMessage string  `json:"statusMessage" yaml:"statusMessage"`
+	Info          []Info  `json:"info" yaml:"info"`
+	Events        []Event `json:"events" yaml:"events"`
+}
+
+type Event struct {
+	Kind           string `json:"kind"`
+	InvolvedObject struct {
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
+	} `json:"involvedObject"`
+	Reason  string `json:"reason"`
+	Message string `json:"message"`
+	Count   int    `json:"count"`
+	Type    string `json:"type"`
 }
 
 type Events struct {
-	Items []struct {
-		Kind           string `json:"kind"`
-		InvolvedObject struct {
-			Namespace string `json:"namespace"`
-			Name      string `json:"name"`
-		} `json:"involvedObject"`
-		Reason  string `json:"reason"`
-		Message string `json:"message"`
-		Count   int    `json:"count"`
-	} `json:"items"`
+	Items []Event `json:"items"`
 }
 
 type DeploymentConfigs struct {
@@ -49,22 +51,23 @@ type DeploymentConfigs struct {
 	} `json:"items"`
 }
 
-type CheckTask func(string, string) (Result, error)
+type CheckTask func(DumpedJSONResourceFactory) (Result, error)
 
 func GetAnalysisTasks(tasks chan<- Task, basepath string, projects []string, results chan<- CheckResults) {
 	// Platform-wide analysis goes here
 
 	// project specific analysis in here
 	for _, p := range projects {
-		tasks <- CheckProjectTask(p, basepath, results)
+		JSONResourceFactory := getDumpedJSONResourceFactory([]string{basepath, "projects", p})
+		tasks <- CheckProjectTask(p, results, JSONResourceFactory)
 	}
 }
 
 // CheckTasks is a task factory for tasks that diagnose system conditions.
-func CheckProjectTask(project, basepath string, results chan<- CheckResults) Task {
+func CheckProjectTask(project string, results chan<- CheckResults, JSONResourceFactory DumpedJSONResourceFactory) Task {
 	return checkProjectTask(func() []CheckTask {
-		return []CheckTask{CheckImagePullBackOff, CheckDeployConfigsReplicasNotZero}
-	}, project, basepath, results)
+		return []CheckTask{CheckEventLogForErrors, CheckDeployConfigsReplicasNotZero}
+	}, JSONResourceFactory, project, results)
 }
 
 // A getProjectCheckFactory generates tasks to diagnose system conditions.
@@ -78,14 +81,14 @@ type CheckResults struct {
 // checkTasks executes all the CheckTasks returned from the supplied
 // checkFactory against the specified project. The results of the checks are
 // combined into a single JSON object and returned
-func checkProjectTask(checkFactory getProjectCheckFactory, project, basepath string, results chan<- CheckResults) Task {
+func checkProjectTask(checkFactory getProjectCheckFactory, JSONResourceFactory DumpedJSONResourceFactory, project string, results chan<- CheckResults) Task {
 	return func() error {
 		result := CheckResults{Scope: project, Results: []Result{}}
 		checks := checkFactory()
 
 		var errors errorList
 		for _, check := range checks {
-			res, err := check(project, basepath)
+			res, err := check(JSONResourceFactory)
 			if err != nil {
 				errors = append(errors, err)
 			}
@@ -102,55 +105,58 @@ func checkProjectTask(checkFactory getProjectCheckFactory, project, basepath str
 	}
 }
 
-// getDumpedResourceAsStruct retrieves the requested resource from the dump directory and
-// decodes the JSON into the provided interface
-func getDumpedResource(path []string, dest interface{}) error {
-	filePath := filepath.Join(path...)
-	contents, err := ioutil.ReadFile(filePath)
+// Takes an array of strings describing the path to a JSON file
+// which will be parsed and loaded into the supplied interface
+type DumpedJSONResourceFactory func([]string, interface{}) error
 
-	decoder := json.NewDecoder(bytes.NewBuffer(contents))
-	err = decoder.Decode(&dest)
-	if err != nil {
-		return err
+// Returns a factory which will load resource from a given basepath. The factory parses the file
+// contents as JSON and loads it into the provided dest interface
+func getDumpedJSONResourceFactory(basepath []string) DumpedJSONResourceFactory {
+
+	return func(path []string, dest interface{}) error {
+		file := filepath.Join(append(basepath, path...)...)
+		contents, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+		decoder := json.NewDecoder(contents)
+		if err := decoder.Decode(&dest); err != nil {
+			return err
+		}
+		return nil
 	}
 
-	return nil
 }
 
-// CheckImagePullBackOff checks all events in the supplied project and if any
-// are exhibiting signs that they have experienced an ImagePullBackOff recently
-// this will be reflected in the returned Result data. Any errors are written to
-// the supplied stdErr writer.
-func CheckImagePullBackOff(project, basepath string) (Result, error) {
-	result := Result{Status: 0, StatusMessage: "this issue was not detected", CheckName: "check deploys for ImagePullBackOff error"}
+// CheckEventLogForErrors checks all events in the supplied project and if any
+// are not type 'Normal' (i.e. Warning or Error), it will add them to the returned results.
+func CheckEventLogForErrors(JSONResourceFactory DumpedJSONResourceFactory) (Result, error) {
+	result := Result{Status: 0, StatusMessage: "this issue was not detected", CheckName: "check eventlog for any errors", Info: []Info{}, Events: []Event{}}
 	events := Events{}
-	err := getDumpedResource([]string{basepath, "projects", project, "definitions", "events.json"}, &events)
-	if err != nil {
+	if err := JSONResourceFactory([]string{"definitions", "events.json"}, &events); err != nil {
 		result.Status = 2
 		result.StatusMessage = "Error executing task"
 		return result, err
 	}
 
 	for _, event := range events.Items {
-		if event.Reason == "FailedSync" && strings.Contains(event.Message, "ImagePullBackOff") {
-			info := Info{Name: event.InvolvedObject.Name, Namespace: event.InvolvedObject.Namespace, Kind: event.Kind, Count: event.Count, Message: event.Message}
+		if event.Type != "Normal" {
 			result.Status = 1
-			result.StatusMessage = "'ImagePullBackOff' error detected"
-			result.Info = append(result.Info, info)
+			result.StatusMessage = "Errors detected in event log"
+			result.Events = append(result.Events, event)
 		}
 	}
 
 	return result, nil
 }
 
-// CheckDeployConfigsReplicasNotZero checks all deployment configs in the
-// supplied project and if any have replicas set to zero this will be reflected
-// in the returned Result data. Any errors are written to the supplied stdErr
-// writer.
-func CheckDeployConfigsReplicasNotZero(project, basepath string) (Result, error) {
-	result := Result{Status: 0, StatusMessage: "this issue was not detected", CheckName: "check deployconfig replicas not 0"}
+// CheckDeployConfigsReplicasNotZero checks all deployment configs in the supplied
+// JSON Resource Factory, and if any are found with a replica of 0, it will add a
+// note about it to the returned result
+func CheckDeployConfigsReplicasNotZero(ResourceFactory DumpedJSONResourceFactory) (Result, error) {
+	result := Result{Status: 0, StatusMessage: "this issue was not detected", CheckName: "check deployconfig replicas not 0", Info: []Info{}, Events: []Event{}}
 	deploymentConfigs := DeploymentConfigs{}
-	err := getDumpedResource([]string{basepath, "projects", project, "definitions", "deploymentconfigs.json"}, &deploymentConfigs)
+	err := ResourceFactory([]string{"definitions", "deploymentconfigs.json"}, &deploymentConfigs)
 	if err != nil {
 		result.Status = 2
 		result.StatusMessage = "Error executing task"

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
 	"testing"
 )
@@ -12,12 +14,16 @@ func mockCheckFactoryOnePass() []CheckTask {
 	return []CheckTask{mockTestOne}
 }
 
-func mockTestOne(project, basepath string) (Result, error) {
+func mockJSONResourceFactory(p []string, d interface{}) error {
+	return nil
+}
+
+func mockTestOne(loader DumpedJSONResourceFactory) (Result, error) {
 	result := Result{StatusMessage: "Called mockTestOne"}
 	return result, nil
 }
 
-func mockTestTwo(project, basepath string) (Result, error) {
+func mockTestTwo(loader DumpedJSONResourceFactory) (Result, error) {
 	result := Result{StatusMessage: "Called mockTestTwo"}
 	return result, errors.New("FAIL")
 }
@@ -25,7 +31,7 @@ func mockTestTwo(project, basepath string) (Result, error) {
 func TestCheckTasksWithFail(t *testing.T) {
 	results := make(chan CheckResults, 1)
 	defer close(results)
-	task := checkProjectTask(mockCheckFactoryOnePassOneFail, "MockProject", "/", results)
+	task := checkProjectTask(mockCheckFactoryOnePassOneFail, mockJSONResourceFactory, "MockProject", results)
 
 	err := task()
 
@@ -42,7 +48,7 @@ func TestCheckTasksWithFail(t *testing.T) {
 func TestCheckTasksWithPass(t *testing.T) {
 	results := make(chan CheckResults, 1)
 	defer close(results)
-	task := checkProjectTask(mockCheckFactoryOnePass, "MockProject", "/", results)
+	task := checkProjectTask(mockCheckFactoryOnePass, mockJSONResourceFactory, "MockProject", results)
 
 	err := task()
 
@@ -53,5 +59,149 @@ func TestCheckTasksWithPass(t *testing.T) {
 	result := <-results
 	if (len(result.Results)) != 1 {
 		t.Fatal("Expected 1 check results, got: " + string(len(result.Results)))
+	}
+}
+
+func mockEventLogWithWarningFactory(p []string, d interface{}) error {
+	contents := `{
+		"kind": "List",
+		"apiVersion": "v1",
+		"metadata": {},
+		"items": [
+			{
+				"kind": "Event",
+				"apiVersion": "v1",
+				"metadata": {
+					"name": "mongodb-2-1-x66za.14691ab157eb4089",
+					"namespace": "qe-3node-4-1",
+					"selfLink": "/api/v1/namespaces/qe-3node-4-1/events/mongodb-2-1-x66za.14691ab157eb4089",
+					"uid": "68dd0b95-5e16-11e6-a344-0abb8905d551",
+					"resourceVersion": "9471053",
+					"creationTimestamp": "2016-08-09T09:48:22Z",
+					"deletionTimestamp": "2016-08-23T16:04:30Z"
+				},
+				"involvedObject": {
+					"kind": "Pod",
+					"namespace": "qe-3node-4-1",
+					"name": "mongodb-2-1-x66za",
+					"uid": "915b7b41-5d33-11e6-9064-0abb8905d551",
+					"apiVersion": "v1",
+					"resourceVersion": "7932636"
+				},
+				"reason": "FailedSync",
+				"message": "Error syncing pod, skipping: API error (500): Unknown device 84d72d4cf06a1e292ba21c36c5c93638ccd3c4cfab8bf048bd434ff9cdf43722\n",
+				"source": {
+					"component": "kubelet",
+					"host": "10.10.0.141"
+				},
+				"firstTimestamp": "2016-08-09T09:48:22Z",
+				"lastTimestamp": "2016-08-23T14:04:30Z",
+				"count": 94215,
+				"type": "Warning"
+			}
+		]
+	}`
+
+	decoder := json.NewDecoder(bytes.NewBuffer([]byte(contents)))
+	err := decoder.Decode(&d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func MockDeployConfigWithReplicaZero(p []string, d interface{}) error {
+	contents := `{
+		"kind": "List",
+		"apiVersion": "v1",
+		"metadata": {},
+		"items": [
+			{
+				"kind": "DeploymentConfig",
+				"apiVersion": "v1",
+				"metadata": {
+					"name": "fh-mbaas",
+					"namespace": "qe-3node-4-1",
+					"labels": {
+						"name": "fh-mbaas"
+					}
+				},
+				"spec": {
+					"replicas": 0,
+					"selector": {
+						"name": "fh-mbaas"
+					},
+					"template": {
+						"metadata": {
+							"labels": {
+								"name": "fh-mbaas"
+							}
+						}
+					}
+				}
+			}
+		]
+	}`
+
+	decoder := json.NewDecoder(bytes.NewBuffer([]byte(contents)))
+	err := decoder.Decode(&d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func mockJSONResourceErrorFactory(p []string, d interface{}) error {
+	return errors.New("mock error")
+}
+
+func TestCheckEventLogForErrors(t *testing.T) {
+	res, err := CheckEventLogForErrors(mockEventLogWithWarningFactory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != 1 {
+		t.Fatal("res.Status expected: 1, got:", res.Status)
+	}
+	if len(res.Events) != 1 {
+		t.Fatal("len(res.Events) expected: 1, got:", len(res.Events))
+	}
+	if res.Events[0].Count != 94215 {
+		t.Fatal("res.Events[0].Count expected: 94215, got:", string(res.Events[0].Count))
+	}
+	if res.Events[0].Type != "Warning" {
+		t.Fatal("res.Events[0].Type expected: 'Warning', got: '" + res.Events[0].Type + "'")
+	}
+	if res.Events[0].Reason != "FailedSync" {
+		t.Fatal("res.Events[0].Reason expected: 'FailedSync', got: '" + res.Events[0].Reason + "'")
+	}
+
+	res, err = CheckEventLogForErrors(mockJSONResourceErrorFactory)
+	if err == nil {
+		t.Fatal("CheckEventLogForErrors(mockJSONResourceErrorFactory) expected error, got none")
+	}
+	if res.Status != 2 {
+		t.Fatal("res.Status expected 2, got:", res.Status)
+	}
+}
+
+func TestCheckDeployConfigsReplicasNotZero(t *testing.T) {
+	res, err := CheckDeployConfigsReplicasNotZero(MockDeployConfigWithReplicaZero)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Status != 1 {
+		t.Fatal("res.Status expected: 1, got:", res.Status)
+	}
+	if res.Info[0].Count != 1 {
+		t.Fatal("res.Info[0].Count expected 1, got:" + string(res.Info[0].Count))
+	}
+
+	res, err = CheckDeployConfigsReplicasNotZero(mockJSONResourceErrorFactory)
+	if err == nil {
+		t.Fatal("CheckDeployConfigsReplicasNotZero(mockJSONResourceErrorFactory) expected error, got none")
+	}
+	if res.Status != 2 {
+		t.Fatal("res.Status expected 2, got:", res.Status)
 	}
 }


### PR DESCRIPTION
# Motivation
The dump tool is intended to check the event log for any errors and add these to the analysis results.

The analysis in the dump tool is not well tested currently.

# Changes
Alter an existing analysis check to check for any errors in the event log, rather than specific errors

Update the analysis code to be more testable.

Add unit tests to the test suite to test the analysis checks.

# Jiras
[RHMAP-9453](https://issues.jboss.org/browse/RHMAP-9453)