### PR TITLE
Fixed specification of project

### DIFF
--- a/millicore.go
+++ b/millicore.go
@@ -20,7 +20,7 @@ func GetMillicoreConfigTasks(tasks chan<- Task, runner Runner, projects []string
 
 func GetMillicoreConfig(r Runner, project, pod string) Task {
 	return func() error {
-		cmd := exec.Command("oc", "exec", pod, "--", "cat", "/etc/feedhenry/cluster-override.properties")
+		cmd := exec.Command("oc", "-n", project, "exec", pod, "--", "cat", "/etc/feedhenry/cluster-override.properties")
 		path := filepath.Join("projects", project, "millicore", pod+"_cluster-override.properties")
 		return r.Run(cmd, path)
 	}

--- a/millicore_test.go
+++ b/millicore_test.go
@@ -22,7 +22,7 @@ func TestGetMillicoreConfigTasks(t *testing.T) {
 	}
 	expectedCalls := []RunCall{
 		{
-			[]string{"oc", "exec", "millicore-1", "--", "cat", "/etc/feedhenry/cluster-override.properties"},
+			[]string{"oc", "-n", "project1", "exec", "millicore-1", "--", "cat", "/etc/feedhenry/cluster-override.properties"},
 			filepath.Join("projects", "project1", "millicore", "millicore-1_cluster-override.properties"),
 		},
 	}

--- a/nagios.go
+++ b/nagios.go
@@ -32,7 +32,7 @@ func GetNagiosTasks(tasks chan<- Task, runner Runner, projects []string) {
 // the given pod in project.
 func GetNagiosStatusData(r Runner, project, pod string) Task {
 	return func() error {
-		cmd := exec.Command("oc", "exec", pod, "--", "cat", "/var/log/nagios/status.dat")
+		cmd := exec.Command("oc", "-n", project, "exec", pod, "--", "cat", "/var/log/nagios/status.dat")
 		fname := pod + "_status.dat"
 		path := filepath.Join("projects", project, "nagios", fname)
 		return r.Run(cmd, path)
@@ -43,7 +43,7 @@ func GetNagiosStatusData(r Runner, project, pod string) Task {
 // archives from the given pod in project.
 func GetNagiosHistoricalData(r Runner, project, pod string) Task {
 	return func() error {
-		cmd := exec.Command("oc", "exec", pod, "--", "tar", "-c", "-C", "/var/log/nagios", "archives")
+		cmd := exec.Command("oc", "-n", project, "exec", pod, "--", "tar", "-c", "-C", "/var/log/nagios", "archives")
 		fname := pod + "_history.tar"
 		path := filepath.Join("projects", project, "nagios", fname)
 		return r.Run(cmd, path)

--- a/nagios_test.go
+++ b/nagios_test.go
@@ -30,7 +30,7 @@ func TestGetNagiosStatusData(t *testing.T) {
 			pod:     "pod",
 			calls: []RunCall{
 				{
-					[]string{"oc", "exec", "pod", "--", "cat", "/var/log/nagios/status.dat"},
+					[]string{"oc", "-n", "test-project", "exec", "pod", "--", "cat", "/var/log/nagios/status.dat"},
 					filepath.Join("projects", "test-project", "nagios", "pod_status.dat"),
 				},
 			},
@@ -58,7 +58,7 @@ func TestGetNagiosHistoricalData(t *testing.T) {
 			pod:     "pod",
 			calls: []RunCall{
 				{
-					[]string{"oc", "exec", "pod", "--", "tar", "-c", "-C", "/var/log/nagios", "archives"},
+					[]string{"oc", "-n", "test-project", "exec", "pod", "--", "tar", "-c", "-C", "/var/log/nagios", "archives"},
 					filepath.Join("projects", "test-project", "nagios", "pod_history.tar"),
 				},
 			},


### PR DESCRIPTION
# Motivation
Currently project is not specified for commands retrieving data from nagios and millicore. Because of that they will only work if there is only one project with these components and it is the oc's current project. Otherwise project have to be specified in the commands.

# Changes
Added specification for project.
