### PR TITLE
Rephrase output when archiving the dumped data fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func main() {
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {
-			log.Printf("Dumped system information to: %s", basePath)
+			log.Printf("There was an error creating archiving the dumped data, so the dumped system information is stored unarchived in: %s", basePath)
 			return
 		}
 


### PR DESCRIPTION
# Motivation
Make it clear to the user that although the archive was not created, the dump data is still accessible, and where it is.

# Changes
Rephrased output when the tar command fails.