### PR TITLE
Continue with dump even when there is no project

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -79,7 +79,6 @@ func GetAllDumpTasks(runner Runner, basepath string) <-chan Task {
 		}
 		if len(projects) == 0 {
 			tasks <- NewError(errors.New("no projects visible to the currently logged in user"))
-			return
 		}
 
 		var wg sync.WaitGroup


### PR DESCRIPTION
# Motivation

Currently when there is no project the dump tool will not run any dump task. There are dump tasks which are platform-wide so these should be run even when there is no project.
# Change

Removed return line in no projects check.
