### PR TITLE
Added configmap to resources

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -98,7 +98,7 @@ func GetAllDumpTasks(runner Runner, basepath string) <-chan Task {
 
 			resources := []string{
 				"deploymentconfigs", "pods", "services",
-				"events", "persistentvolumeclaims",
+				"events", "persistentvolumeclaims", "configmaps",
 			}
 			GetResourceDefinitionTasks(tasks, runner, projects, resources)
 


### PR DESCRIPTION
# Motivation
https://issues.jboss.org/browse/RHMAP-8122
Dump tool should also retrieve platform versions. Versions are stored in configmap.

# Change
Added configmap to resources to be dumped.