### PR TITLE
Take version from Git in build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+ifndef FH_SYSTEM_DUMP_TOOL_VERSION
+FH_SYSTEM_DUMP_TOOL_VERSION := $(shell git describe --tags --abbrev=14)
+endif
+LDFLAGS := -X main.Version=$(FH_SYSTEM_DUMP_TOOL_VERSION)
+
+.PHONY: all
+all:
+	@go install -v -ldflags '$(LDFLAGS)'
+
+.PHONY: clean
+clean:
+	@-go clean -i

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ This repository contains the system dump tool for the RHMAP On-Prem product.
 
 ## Building
 
-Building requires Go 1.6.
+Building requires Go 1.6 or later. The code can be built using the standard Go
+tools, `go build`, `go install` and `go get`. However, use `make` for release
+binaries that include version information:
 
 ```
-go build
+make
 ```
 
 ## Runtime Prerequisites
@@ -56,10 +58,9 @@ Update the function `CheckTasks` to also return your new check function.
 
 ## Releasing
 
-* Clone the repo locally
-* Bump the version in `main.go`
-* Do a `go build`
+* Tag a new version, e.g., `v0.1.0`
 * Create a new __Release__ from the [releases](https://github.com/feedhenry/fh-system-dump-tool/releases) page
-* Add some info about the release, including the version as a tag e.g. `v0.1.0`
+* Add some info about the release
+* Build a release binary using `make`
 * Upload the built binary
 * Publish it

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ func main() {
 
 	var b bytes.Buffer
 	PrintVersion(&b)
-	if err := ioutil.WriteFile(filepath.Join(basePath, ".version"), b.Bytes(), 0660); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(basePath, "version"), b.Bytes(), 0660); err != nil {
 		log.Fatalln("Error:", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -27,9 +27,6 @@ const (
 	// defaultMaxLogLines is the default limit of number of log lines to
 	// fetch.
 	defaultMaxLogLines = 1000
-
-	// The version of the fh-system-dump-tool
-	version = "0.1.0"
 )
 
 var (
@@ -138,7 +135,7 @@ func main() {
 	flag.Parse()
 
 	if *printVersion {
-		fmt.Println("RHMAP fh-system-dump-tool v" + version)
+		PrintVersion(os.Stdout)
 		os.Exit(0)
 	}
 
@@ -156,7 +153,7 @@ func main() {
 		log.Fatalln("Error:", err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(basePath, ".version"), []byte(version), 0660); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(basePath, ".version"), []byte(Version), 0660); err != nil {
 		log.Fatalln("Error:", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -153,7 +153,9 @@ func main() {
 		log.Fatalln("Error:", err)
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(basePath, ".version"), []byte(Version), 0660); err != nil {
+	var b bytes.Buffer
+	PrintVersion(&b)
+	if err := ioutil.WriteFile(filepath.Join(basePath, ".version"), b.Bytes(), 0660); err != nil {
 		log.Fatalln("Error:", err)
 	}
 

--- a/version.go
+++ b/version.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"io"
+)
+
+// Version information, injected at build time.
+var Version = "development version"
+
+// PrintVersion prints version information to w.
+func PrintVersion(w io.Writer) {
+	fmt.Fprintln(w, "RHMAP fh-system-dump-tool", Version)
+}


### PR DESCRIPTION
As part of having a standard build environment for building releases, this PR introduces a Makefile to use for "standard builds".

The code base is still buildable with the standard go tool without any special flag, though using `make` we consistently add version information taken from Git and loaded into the built binary.

Note that this doesn't yet give us a build environment for community releases, this is something we may investigate separately (e.g., using Travis and integrating with GitHub).

--- 

https://issues.jboss.org/browse/RHMAP-9400