### PR TITLE
output from analysis - RHMAP-9595

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -2,8 +2,14 @@ package main
 
 import (
 	"encoding/json"
-	"os"
+	"io/ioutil"
 	"path/filepath"
+)
+
+const (
+	analysisErrorNotDiscovered = iota
+	analysisErrorReadingDumpedResource
+	analysisErrorDiscoveredByAnalysis
 )
 
 // Info is a piece of information regarding a check, multiple Info can be
@@ -95,6 +101,9 @@ type Pods struct {
 // CheckTask is the interface which checks must implement.
 type CheckTask func(DumpedJSONResourceFactory) (Result, error)
 
+// AnalysisResults is a representation of the JSON analysis results file.
+type AnalysisResults map[string]map[string][]Result
+
 // GetAnalysisTasks creates all the analysis tasks and sends them one by one
 // down the tasks Channel.
 func GetAnalysisTasks(tasks chan<- Task, basepath string, projects []string, results chan<- CheckResults) {
@@ -102,7 +111,7 @@ func GetAnalysisTasks(tasks chan<- Task, basepath string, projects []string, res
 
 	// project specific analysis in here.
 	for _, p := range projects {
-		JSONResourceFactory := getDumpedJSONResourceFactory([]string{basepath, "projects", p})
+		JSONResourceFactory := getDumpedJSONResourceFactory(filepath.Join(basepath, "projects", p))
 		tasks <- CheckProjectTask(p, results, JSONResourceFactory)
 	}
 }
@@ -121,6 +130,7 @@ type getProjectCheckFactory func() []CheckTask
 // project or platform-wide.
 type CheckResults struct {
 	Scope   string `json:"scope"`
+	Name    string `json:"name,omitempty"`
 	Results []Result
 }
 
@@ -129,7 +139,7 @@ type CheckResults struct {
 // combined into a single JSON object and returned.
 func checkProjectTask(checkFactory getProjectCheckFactory, JSONResourceFactory DumpedJSONResourceFactory, project string, results chan<- CheckResults) Task {
 	return func() error {
-		result := CheckResults{Scope: project, Results: []Result{}}
+		result := CheckResults{Scope: "project", Name: project, Results: []Result{}}
 		checks := checkFactory()
 
 		var errors errorList
@@ -151,34 +161,29 @@ func checkProjectTask(checkFactory getProjectCheckFactory, JSONResourceFactory D
 	}
 }
 
-// DumpedJSONResourceFactory takes an array of strings describing the path to a
+// DumpedJSONResourceFactory takes a string containing the path to a
 // JSON file which will be parsed and loaded into the supplied interface.
-type DumpedJSONResourceFactory func([]string, interface{}) error
+type DumpedJSONResourceFactory func(string, interface{}) error
 
 // getDumpedJSONResourceFactory returns a factory which will load resource from
 // a given basepath. The factory parses the file contents as JSON and loads it
 // into the provided dest interface.
-func getDumpedJSONResourceFactory(basepath []string) DumpedJSONResourceFactory {
-	return func(path []string, dest interface{}) error {
-		file := filepath.Join(append(basepath, path...)...)
-		contents, err := os.Open(file)
+func getDumpedJSONResourceFactory(basepath string) DumpedJSONResourceFactory {
+	return func(path string, dest interface{}) error {
+		contents, err := ioutil.ReadFile(filepath.Join(basepath, path))
 		if err != nil {
 			return err
 		}
-		decoder := json.NewDecoder(contents)
-		if err := decoder.Decode(&dest); err != nil {
-			return err
-		}
-		return nil
+		return json.Unmarshal(contents, dest)
 	}
 }
 
 // CheckForWaitingPods checks all pods for any containers in waiting status.
 func CheckForWaitingPods(JSONResourceFactory DumpedJSONResourceFactory) (Result, error) {
-	result := Result{Status: 0, StatusMessage: "this issue was not detected", CheckName: "check pods for 'waiting' containers", Info: []Info{}, Events: []Event{}}
+	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check pods for 'waiting' containers", Info: []Info{}, Events: []Event{}}
 	pods := Pods{}
-	if err := JSONResourceFactory([]string{"definitions", "pods.json"}, &pods); err != nil {
-		result.Status = 2
+	if err := JSONResourceFactory(filepath.Join("definitions", "pods.json"), &pods); err != nil {
+		result.Status = analysisErrorReadingDumpedResource
 		result.StatusMessage = "Error executing task: " + err.Error()
 		return result, err
 	}
@@ -186,7 +191,7 @@ func CheckForWaitingPods(JSONResourceFactory DumpedJSONResourceFactory) (Result,
 	for _, pod := range pods.Items {
 		for _, container := range pod.Status.ContainerStatuses {
 			if container.State.Waiting != nil {
-				result.Status = 1
+				result.Status = analysisErrorDiscoveredByAnalysis
 				result.StatusMessage = "Waiting containers have been detected"
 				msg := "container " + container.Name + " in pod " + pod.Metadata.Name + " is in waiting state"
 				info := Info{Name: container.Name, Count: 1, Namespace: pod.Metadata.Namespace, Kind: "container", Message: msg}
@@ -202,17 +207,17 @@ func CheckForWaitingPods(JSONResourceFactory DumpedJSONResourceFactory) (Result,
 // are not type 'Normal' (i.e. Warning or Error), it will add them to the
 // returned results.
 func CheckEventLogForErrors(JSONResourceFactory DumpedJSONResourceFactory) (Result, error) {
-	result := Result{Status: 0, StatusMessage: "this issue was not detected", CheckName: "check eventlog for any errors", Info: []Info{}, Events: []Event{}}
+	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check eventlog for any errors", Info: []Info{}, Events: []Event{}}
 	events := Events{}
-	if err := JSONResourceFactory([]string{"definitions", "events.json"}, &events); err != nil {
-		result.Status = 2
-		result.StatusMessage = "Error executing task"
+	if err := JSONResourceFactory(filepath.Join("definitions", "events.json"), &events); err != nil {
+		result.Status = analysisErrorReadingDumpedResource
+		result.StatusMessage = "Error executing task: " + err.Error()
 		return result, err
 	}
 
 	for _, event := range events.Items {
 		if event.Type != "Normal" {
-			result.Status = 1
+			result.Status = analysisErrorDiscoveredByAnalysis
 			result.StatusMessage = "Errors detected in event log"
 			result.Events = append(result.Events, event)
 		}
@@ -225,19 +230,19 @@ func CheckEventLogForErrors(JSONResourceFactory DumpedJSONResourceFactory) (Resu
 // supplied JSON Resource Factory, and if any are found with a replica of 0, it
 // will add a note about it to the returned result.
 func CheckDeployConfigsReplicasNotZero(ResourceFactory DumpedJSONResourceFactory) (Result, error) {
-	result := Result{Status: 0, StatusMessage: "this issue was not detected", CheckName: "check deployconfig replicas not 0", Info: []Info{}, Events: []Event{}}
+	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check deployconfig replicas not 0", Info: []Info{}, Events: []Event{}}
 	deploymentConfigs := DeploymentConfigs{}
-	err := ResourceFactory([]string{"definitions", "deploymentconfigs.json"}, &deploymentConfigs)
+	err := ResourceFactory(filepath.Join("definitions", "deploymentconfigs.json"), &deploymentConfigs)
 	if err != nil {
-		result.Status = 2
-		result.StatusMessage = "Error executing task"
+		result.Status = analysisErrorReadingDumpedResource
+		result.StatusMessage = "Error executing task: " + err.Error()
 		return result, err
 	}
 
 	for _, deploymentConfig := range deploymentConfigs.Items {
 		if deploymentConfig.Spec.Replicas == 0 {
 			info := Info{Name: deploymentConfig.Metadata.Name, Namespace: deploymentConfig.Metadata.Namespace, Kind: deploymentConfig.Kind, Count: 1, Message: "the replica parameter is set to 0, this should be greater than 0"}
-			result.Status = 1
+			result.Status = analysisErrorDiscoveredByAnalysis
 			result.StatusMessage = "one or more deployConfig replicas are set to 0"
 			result.Info = append(result.Info, info)
 		}

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -14,7 +14,7 @@ func mockCheckFactoryOnePass() []CheckTask {
 	return []CheckTask{mockTestOne}
 }
 
-func mockJSONResourceFactory(p []string, d interface{}) error {
+func mockJSONResourceFactory(p string, d interface{}) error {
 	return nil
 }
 
@@ -62,7 +62,7 @@ func TestCheckTasksWithPass(t *testing.T) {
 	}
 }
 
-func mockJSONResourceErrorFactory(p []string, d interface{}) error {
+func mockJSONResourceErrorFactory(p string, d interface{}) error {
 	return errors.New("mock error")
 }
 
@@ -70,7 +70,7 @@ func mockJSONResourceErrorFactory(p []string, d interface{}) error {
 // Tests and mocks for CheckEventLogForErrors
 //
 
-func mockEventLogWithWarningFactory(p []string, d interface{}) error {
+func mockEventLogWithWarningFactory(p string, d interface{}) error {
 	contents := `{
 		"kind": "List",
 		"apiVersion": "v1",
@@ -123,8 +123,8 @@ func TestCheckEventLogForErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != 1 {
-		t.Fatal("res.Status expected: 1, got:", res.Status)
+	if res.Status != analysisErrorDiscoveredByAnalysis {
+		t.Fatal("res.Status expected:", analysisErrorDiscoveredByAnalysis, "got:", res.Status)
 	}
 	if len(res.Events) != 1 {
 		t.Fatal("len(res.Events) expected: 1, got:", len(res.Events))
@@ -143,8 +143,8 @@ func TestCheckEventLogForErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("CheckEventLogForErrors(mockJSONResourceErrorFactory) expected error, got none")
 	}
-	if res.Status != 2 {
-		t.Fatal("res.Status expected 2, got:", res.Status)
+	if res.Status != analysisErrorReadingDumpedResource {
+		t.Fatal("res.Status expected:", analysisErrorReadingDumpedResource, "got:", res.Status)
 	}
 }
 
@@ -152,7 +152,7 @@ func TestCheckEventLogForErrors(t *testing.T) {
 // Tests and mocks for CheckDeployConfigsReplicasNotZero
 //
 
-func MockDeployConfigWithReplicaZero(p []string, d interface{}) error {
+func MockDeployConfigWithReplicaZero(p string, d interface{}) error {
 	contents := `{
 		"kind": "List",
 		"apiVersion": "v1",
@@ -198,8 +198,8 @@ func TestCheckDeployConfigsReplicasNotZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != 1 {
-		t.Fatal("res.Status expected: 1, got:", res.Status)
+	if res.Status != analysisErrorDiscoveredByAnalysis {
+		t.Fatal("res.Status expected:", analysisErrorDiscoveredByAnalysis, "got:", res.Status)
 	}
 	if res.Info[0].Count != 1 {
 		t.Fatal("res.Info[0].Count expected 1, got:" + string(res.Info[0].Count))
@@ -209,8 +209,8 @@ func TestCheckDeployConfigsReplicasNotZero(t *testing.T) {
 	if err == nil {
 		t.Fatal("CheckDeployConfigsReplicasNotZero(mockJSONResourceErrorFactory) expected error, got none")
 	}
-	if res.Status != 2 {
-		t.Fatal("res.Status expected 2, got:", res.Status)
+	if res.Status != analysisErrorReadingDumpedResource {
+		t.Fatal("res.Status expected", analysisErrorReadingDumpedResource, "got:", res.Status)
 	}
 }
 
@@ -218,7 +218,7 @@ func TestCheckDeployConfigsReplicasNotZero(t *testing.T) {
 // Tests and mocks for CheckForWaitingPods
 //
 
-func MockPodsWithWaitingPod(p []string, d interface{}) error {
+func MockPodsWithWaitingPod(p string, d interface{}) error {
 	contents := `{
 		"items": [
 			{
@@ -251,7 +251,7 @@ func MockPodsWithWaitingPod(p []string, d interface{}) error {
 	return nil
 }
 
-func MockPodsWithoutWaitingPod(p []string, d interface{}) error {
+func MockPodsWithoutWaitingPod(p string, d interface{}) error {
 	contents := `{
 		"items": [
 			{
@@ -283,7 +283,7 @@ func MockPodsWithoutWaitingPod(p []string, d interface{}) error {
 	return nil
 }
 
-func MockEmptyPods(p []string, d interface{}) error {
+func MockEmptyPods(p string, d interface{}) error {
 	contents := `{
 		"items": [
 		]
@@ -302,8 +302,8 @@ func TestCheckForWaitingPods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != 1 {
-		t.Fatal("res.Status expected: 1, got:", res.Status)
+	if res.Status != analysisErrorDiscoveredByAnalysis {
+		t.Fatal("res.Status expected:", analysisErrorDiscoveredByAnalysis, " got:", res.Status)
 	}
 	if res.Info[0].Count != 1 {
 		t.Fatal("res.Info[0].Count expected 1, got:" + string(res.Info[0].Count))
@@ -313,8 +313,8 @@ func TestCheckForWaitingPods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != 0 {
-		t.Fatal("res.Status expected: 0, got:", res.Status)
+	if res.Status != analysisErrorNotDiscovered {
+		t.Fatal("res.Status expected:", analysisErrorNotDiscovered, "got:", res.Status)
 	}
 	if len(res.Info) != 0 {
 		t.Fatal("len(res.Info) expected 0, got:" + string(len(res.Info)))
@@ -324,8 +324,8 @@ func TestCheckForWaitingPods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != 0 {
-		t.Fatal("res.Status expected: 0, got:", res.Status)
+	if res.Status != analysisErrorNotDiscovered {
+		t.Fatal("res.Status expected:", analysisErrorNotDiscovered, "got:", res.Status)
 	}
 	if len(res.Info) != 0 {
 		t.Fatal("len(res.Info) expected 0, got:" + string(len(res.Info)))
@@ -335,7 +335,7 @@ func TestCheckForWaitingPods(t *testing.T) {
 	if err == nil {
 		t.Fatal("CheckDeployConfigsReplicasNotZero(mockJSONResourceErrorFactory) expected error, got none")
 	}
-	if res.Status != 2 {
-		t.Fatal("res.Status expected 2, got:", res.Status)
+	if res.Status != analysisErrorReadingDumpedResource {
+		t.Fatal("res.Status expected ", analysisErrorReadingDumpedResource, "got:", res.Status)
 	}
 }

--- a/dump_writers.go
+++ b/dump_writers.go
@@ -27,7 +27,3 @@ func outToFile(basepath, extension, scope string) projectResourceWriterCloserFac
 		return f, f, nil
 	}
 }
-
-// A pathResourceWriterFactory generates io.Writers for dumping data of a
-// particular resource type within a project.
-type pathResourceWriterCloserFactory func() (io.Writer, io.Closer, error)

--- a/main.go
+++ b/main.go
@@ -180,7 +180,7 @@ func main() {
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
 		if err := cmd.Run(); err != nil {
-			log.Printf("There was an error creating archiving the dumped data, so the dumped system information is stored unarchived in: %s", basePath)
+			log.Printf("There was an error archiving the dumped data, so the dumped system information is stored unarchived in: %s", basePath)
 			return
 		}
 
@@ -197,8 +197,14 @@ func main() {
 
 	runner := NewDumpRunner(basePath)
 
-	log.Print("Running dump tasks...")
+	log.Print("Running dump and analyse tasks...")
 	RunAllDumpTasks(runner, basePath, *concurrentTasks)
-	log.Print("Running analysis tasks...")
-	RunAllAnalysisTasks(runner, basePath, *concurrentTasks)
+	analysisResults := RunAllAnalysisTasks(runner, basePath, *concurrentTasks)
+
+	delta := time.Since(start)
+	// Remove sub-second precision.
+	delta -= delta % time.Second
+	log.Printf("Run all tasks in %v.", delta)
+
+	RunOutputTask(os.Stdout, os.Stderr, analysisResults)
 }

--- a/output_results.go
+++ b/output_results.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// RunOutputTask will read in the analysis.json file and output
+// any useful information to o or any errors to e.
+func RunOutputTask(o io.Writer, e io.Writer, analysisResults AnalysisResults) {
+	for _, projects := range analysisResults {
+		for project, results := range projects {
+			for _, result := range results {
+				if result.Status != 0 {
+					fmt.Fprintf(o, "Potential issue discovered in %s: %s\n", project, result.CheckName)
+					fmt.Fprintf(o, "  Details:\n")
+					for _, info := range result.Info {
+						fmt.Fprintf(o, "    %s\n", strings.Replace(strings.TrimSpace(info.Message), "\n", "\n    ", -1))
+					}
+					for _, event := range result.Events {
+						fmt.Fprintf(o, "    %s\n", strings.Replace(strings.TrimSpace(event.Message), "\n", "\n    ", -1))
+					}
+				}
+			}
+		}
+	}
+}

--- a/output_results_test.go
+++ b/output_results_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func mockAnalysisNoErrors(p string, d interface{}) error {
+	contents := `{
+		"projects": {
+			"dev": [
+				{
+					"checkName": "check eventlog for any errors",
+					"status": 0,
+					"statusMessage": "this issue was not detected",
+					"info": [],
+					"events": []
+				},
+				{
+					"checkName": "check deployconfig replicas not 0",
+					"status": 0,
+					"statusMessage": "this issue was not detected",
+					"info": [],
+					"events": []
+				},
+				{
+					"checkName": "check pods for 'waiting' containers",
+					"status": 0,
+					"statusMessage": "this issue was not detected",
+					"info": [],
+					"events": []
+				}
+			]
+		}
+	}`
+
+	decoder := json.NewDecoder(bytes.NewBuffer([]byte(contents)))
+	err := decoder.Decode(&d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func mockAnalysisErrors(p string, d interface{}) error {
+	contents := `{
+		"projects": {
+			"rhmap-core": [
+				{
+					"checkName": "check eventlog for any errors",
+					"status": 1,
+					"statusMessage": "Errors detected in event log",
+					"info": [],
+					"events": [
+						{
+							"kind": "Event",
+							"involvedObject": {
+								"namespace": "rhmap-core",
+								"name": "fh-ngui"
+							},
+							"reason": "FailedUpdate",
+							"message": "Cannot update deployment rhmap-core/fh-ngui-3 status to Pending: replicationcontrollers \"fh-ngui-3\" cannot be updated: the object has been modified; please apply your changes to the latest version and try again",
+							"count": 1,
+							"type": "Warning"
+						}
+					]
+				}
+			]
+		}
+	}`
+
+	decoder := json.NewDecoder(bytes.NewBuffer([]byte(contents)))
+	err := decoder.Decode(&d)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestRunOutputTaskNoErrors(t *testing.T) {
+	o := bytes.NewBuffer([]byte{})
+	e := bytes.NewBuffer([]byte{})
+	analysisResults := AnalysisResults{}
+	mockAnalysisNoErrors("", &analysisResults)
+	RunOutputTask(o, e, analysisResults)
+
+	if got := len(o.Bytes()); got > 0 {
+		t.Fatal("len(o.Bytes()), expected: 0, got:", got)
+	}
+	if got := len(e.Bytes()); got > 0 {
+		t.Fatal("len(e.Bytes()), expected: 0, got:", got)
+	}
+}
+
+func TestRunOutputTaskFoundErrors(t *testing.T) {
+	o := bytes.NewBuffer([]byte{})
+	e := bytes.NewBuffer([]byte{})
+	analysisResults := AnalysisResults{}
+	mockAnalysisErrors("", &analysisResults)
+	RunOutputTask(o, e, analysisResults)
+
+	if !strings.Contains(string(o.Bytes()), "rhmap-core") {
+		t.Fatal("string(o.Bytes()), expected: to contain 'rhmap-core', got:", string(o.Bytes()))
+	}
+	if got := len(e.Bytes()); got > 0 {
+		t.Fatal("len(e.Bytes()), expected: 0, got:", got)
+	}
+}


### PR DESCRIPTION
# Motivation
When dump and analyse is complete, output any discovered issues to the user on stdout. 

# Changes
Add task to run after analysis.json is finished being written to output any discovered errors.

Example output:
```
Potential issue discovered in rhmap-core: check eventlog for any errors
  Details:
    Readiness probe failed: Get http://10.1.6.13:8080/sys/info/ping: dial tcp 10.1.6.13:8080: connection refused
    Cannot update deployment rhmap-core/fh-supercore-3 status to Pending: replicationcontrollers "fh-supercore-3" cannot be updated: the object has been modified; please apply your changes to the latest version and try again
Potential issue discovered in testingcloudapp1oldrr64: check eventlog for any errors
  Details:
    Cannot update deployment testingcloudapp1oldrr64/nodejs-frontend-1 status to Pending: replicationcontrollers "nodejs-frontend-1" cannot be updated: the object has been modified; please apply your changes to the latest version and try again
    Cannot update deployment testingcloudapp1oldrr64/redis-1 status to Pending: replicationcontrollers "redis-1" cannot be updated: the object has been modified; please apply your changes to the latest version and try again
Potential issue discovered in testingcloudappolderr64: check eventlog for any errors
  Details:
    Cannot update deployment testingcloudappolderr64/nodejs-frontend-1 status to Pending: replicationcontrollers "nodejs-frontend-1" cannot be updated: the object has been modified; please apply your changes to the latest version and try again
    Cannot update deployment testingcloudappolderr64/redis-1 status to Pending: replicationcontrollers "redis-1" cannot be updated: the object has been modified; please apply your changes to the latest version and try again
2016/09/07 15:54:25 Dumped system information to: rhmap-dumps/2016-09-07T14-53-57Z.tar.gz
```

This has discovered errors in 3 different projects:
-  rhmap-core
- testingcloudapp1oldrr64
- testingcloudappolderr64

I am not sure if this format is the most ideal, and I am open to suggestions, the problem really seems to be that there is quite a lot of text to output. So possibly it could look more brief like:
```
Potential issue discovered in rhmap-core: check eventlog for any errors
   For more information check the analysis.json in the archive
Potential issue discovered in testingcloudapp1oldrr64: check eventlog for any errors
   For more information check the analysis.json in the archive
Potential issue discovered in testingcloudappolderr64: check eventlog for any errors
   For more information check the analysis.json in the archive
```

Which is less immediately useful, but is far less clutter on the screen. Any thoughts?