### PR TITLE
Extract archive logic to a function

### DIFF
--- a/main.go
+++ b/main.go
@@ -124,7 +124,7 @@ func main() {
 		fileOnlyLogger.Printf("Dumped system information to: %s", basePath)
 
 		if err := archive(basePath); err != nil {
-			log.Printf("There was an error archiving the dumped data, so the dumped system information is stored unarchived in: %s", basePath)
+			log.Printf("Could not archive dump data, unarchived data in: %s", basePath)
 			return
 		}
 		// The archive was created successfully, remove basePath. The

--- a/main.go
+++ b/main.go
@@ -72,6 +72,15 @@ func readSpaceSeparated(r io.Reader) ([]string, error) {
 	return words, nil
 }
 
+// archive archives the target path to a tar.gz file.
+func archive(path string) error {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("tar", "-czf", path+".tar.gz", path)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	return cmd.Run()
+}
+
 func main() {
 	flag.Parse()
 
@@ -114,16 +123,10 @@ func main() {
 		// basePath. After that, logs will go only to stderr.
 		fileOnlyLogger.Printf("Dumped system information to: %s", basePath)
 
-		var stdout, stderr bytes.Buffer
-
-		cmd := exec.Command("tar", "-czf", basePath+".tar.gz", basePath)
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		if err := cmd.Run(); err != nil {
+		if err := archive(basePath); err != nil {
 			log.Printf("There was an error archiving the dumped data, so the dumped system information is stored unarchived in: %s", basePath)
 			return
 		}
-
 		// The archive was created successfully, remove basePath. The
 		// error from os.RemoveAll is intentionally ignored, since there
 		// is no useful action we can do, and we don't need to confuse

--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func main() {
 		fileOnlyLogger.Printf("Dumped system information to: %s", basePath)
 
 		if err := archive(basePath); err != nil {
+			fileOnlyLogger.Printf("Could not create data archive: %v", err)
 			log.Printf("Could not archive dump data, unarchived data in: %s", basePath)
 			return
 		}


### PR DESCRIPTION
This is an attempt to remove some code from `main`, and has the benefit that we can reimplement `archive` later without depending on `tar` if we decide so.

Also reviving the discussion from #40, wrt the error message when `tar` fails.