### PR TITLE
Refactor analysis

### DIFF
--- a/analysis.go
+++ b/analysis.go
@@ -17,7 +17,6 @@ const (
 type Info struct {
 	Name      string
 	Namespace string
-	Kind      string
 	Message   string
 }
 
@@ -192,7 +191,7 @@ func CheckForWaitingPods(JSONResourceFactory DumpedJSONResourceFactory) (Result,
 				result.Status = analysisErrorDiscoveredByAnalysis
 				result.StatusMessage = "Waiting containers have been detected"
 				msg := "container " + container.Name + " in pod " + pod.Metadata.Name + " is in waiting state"
-				info := Info{Name: container.Name, Namespace: pod.Metadata.Namespace, Kind: "container", Message: msg}
+				info := Info{Name: container.Name, Namespace: pod.Metadata.Namespace, Message: msg}
 				result.Info = append(result.Info, info)
 			}
 		}
@@ -239,7 +238,7 @@ func CheckDeployConfigsReplicasNotZero(ResourceFactory DumpedJSONResourceFactory
 
 	for _, deploymentConfig := range deploymentConfigs.Items {
 		if deploymentConfig.Spec.Replicas == 0 {
-			info := Info{Name: deploymentConfig.Metadata.Name, Namespace: deploymentConfig.Metadata.Namespace, Kind: deploymentConfig.Kind, Message: "the replica parameter is set to 0, this should be greater than 0"}
+			info := Info{Name: deploymentConfig.Metadata.Name, Namespace: deploymentConfig.Metadata.Namespace, Message: "the replica parameter is set to 0, this should be greater than 0"}
 			result.Status = analysisErrorDiscoveredByAnalysis
 			result.StatusMessage = "one or more deployConfig replicas are set to 0"
 			result.Info = append(result.Info, info)

--- a/analysis.go
+++ b/analysis.go
@@ -28,8 +28,8 @@ type Result struct {
 	CheckName     string  `json:"checkName"`
 	Status        int     `json:"status"`
 	StatusMessage string  `json:"statusMessage"`
-	Info          []Info  `json:"info"`
-	Events        []Event `json:"events"`
+	Info          []Info  `json:"info,omitempty"`
+	Events        []Event `json:"events,omitempty"`
 }
 
 // Some of the types below are taken from:
@@ -179,7 +179,7 @@ func getDumpedJSONResourceFactory(basepath string) DumpedJSONResourceFactory {
 
 // CheckForWaitingPods checks all pods for any containers in waiting status.
 func CheckForWaitingPods(JSONResourceFactory DumpedJSONResourceFactory) (Result, error) {
-	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check pods for 'waiting' containers", Info: []Info{}, Events: []Event{}}
+	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check pods for 'waiting' containers"}
 	var pods Pods
 	if err := JSONResourceFactory(filepath.Join("definitions", "pods.json"), &pods); err != nil {
 		result.Status = analysisErrorReadingDumpedResource
@@ -206,7 +206,7 @@ func CheckForWaitingPods(JSONResourceFactory DumpedJSONResourceFactory) (Result,
 // are not type 'Normal' (i.e. Warning or Error), it will add them to the
 // returned results.
 func CheckEventLogForErrors(JSONResourceFactory DumpedJSONResourceFactory) (Result, error) {
-	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check eventlog for any errors", Info: []Info{}, Events: []Event{}}
+	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check eventlog for any errors"}
 	var events Events
 	if err := JSONResourceFactory(filepath.Join("definitions", "events.json"), &events); err != nil {
 		result.Status = analysisErrorReadingDumpedResource
@@ -229,7 +229,7 @@ func CheckEventLogForErrors(JSONResourceFactory DumpedJSONResourceFactory) (Resu
 // supplied JSON Resource Factory, and if any are found with a replica of 0, it
 // will add a note about it to the returned result.
 func CheckDeployConfigsReplicasNotZero(ResourceFactory DumpedJSONResourceFactory) (Result, error) {
-	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check deployconfig replicas not 0", Info: []Info{}, Events: []Event{}}
+	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check deployconfig replicas not 0"}
 	var deploymentConfigs DeploymentConfigs
 	err := ResourceFactory(filepath.Join("definitions", "deploymentconfigs.json"), &deploymentConfigs)
 	if err != nil {

--- a/analysis.go
+++ b/analysis.go
@@ -18,7 +18,6 @@ type Info struct {
 	Name      string
 	Namespace string
 	Kind      string
-	Count     int
 	Message   string
 }
 
@@ -193,7 +192,7 @@ func CheckForWaitingPods(JSONResourceFactory DumpedJSONResourceFactory) (Result,
 				result.Status = analysisErrorDiscoveredByAnalysis
 				result.StatusMessage = "Waiting containers have been detected"
 				msg := "container " + container.Name + " in pod " + pod.Metadata.Name + " is in waiting state"
-				info := Info{Name: container.Name, Count: 1, Namespace: pod.Metadata.Namespace, Kind: "container", Message: msg}
+				info := Info{Name: container.Name, Namespace: pod.Metadata.Namespace, Kind: "container", Message: msg}
 				result.Info = append(result.Info, info)
 			}
 		}
@@ -240,7 +239,7 @@ func CheckDeployConfigsReplicasNotZero(ResourceFactory DumpedJSONResourceFactory
 
 	for _, deploymentConfig := range deploymentConfigs.Items {
 		if deploymentConfig.Spec.Replicas == 0 {
-			info := Info{Name: deploymentConfig.Metadata.Name, Namespace: deploymentConfig.Metadata.Namespace, Kind: deploymentConfig.Kind, Count: 1, Message: "the replica parameter is set to 0, this should be greater than 0"}
+			info := Info{Name: deploymentConfig.Metadata.Name, Namespace: deploymentConfig.Metadata.Namespace, Kind: deploymentConfig.Kind, Message: "the replica parameter is set to 0, this should be greater than 0"}
 			result.Status = analysisErrorDiscoveredByAnalysis
 			result.StatusMessage = "one or more deployConfig replicas are set to 0"
 			result.Info = append(result.Info, info)

--- a/analysis.go
+++ b/analysis.go
@@ -180,7 +180,7 @@ func getDumpedJSONResourceFactory(basepath string) DumpedJSONResourceFactory {
 // CheckForWaitingPods checks all pods for any containers in waiting status.
 func CheckForWaitingPods(JSONResourceFactory DumpedJSONResourceFactory) (Result, error) {
 	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check pods for 'waiting' containers", Info: []Info{}, Events: []Event{}}
-	pods := Pods{}
+	var pods Pods
 	if err := JSONResourceFactory(filepath.Join("definitions", "pods.json"), &pods); err != nil {
 		result.Status = analysisErrorReadingDumpedResource
 		result.StatusMessage = "Error executing task: " + err.Error()
@@ -207,7 +207,7 @@ func CheckForWaitingPods(JSONResourceFactory DumpedJSONResourceFactory) (Result,
 // returned results.
 func CheckEventLogForErrors(JSONResourceFactory DumpedJSONResourceFactory) (Result, error) {
 	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check eventlog for any errors", Info: []Info{}, Events: []Event{}}
-	events := Events{}
+	var events Events
 	if err := JSONResourceFactory(filepath.Join("definitions", "events.json"), &events); err != nil {
 		result.Status = analysisErrorReadingDumpedResource
 		result.StatusMessage = "Error executing task: " + err.Error()
@@ -230,7 +230,7 @@ func CheckEventLogForErrors(JSONResourceFactory DumpedJSONResourceFactory) (Resu
 // will add a note about it to the returned result.
 func CheckDeployConfigsReplicasNotZero(ResourceFactory DumpedJSONResourceFactory) (Result, error) {
 	result := Result{Status: analysisErrorNotDiscovered, StatusMessage: "this issue was not detected", CheckName: "check deployconfig replicas not 0", Info: []Info{}, Events: []Event{}}
-	deploymentConfigs := DeploymentConfigs{}
+	var deploymentConfigs DeploymentConfigs
 	err := ResourceFactory(filepath.Join("definitions", "deploymentconfigs.json"), &deploymentConfigs)
 	if err != nil {
 		result.Status = analysisErrorReadingDumpedResource

--- a/analysis.go
+++ b/analysis.go
@@ -25,11 +25,11 @@ type Info struct {
 // Result is a result of a single check, it can have multiple Event and Info
 // objects attached to it.
 type Result struct {
-	CheckName     string  `json:"checkName" yaml:"checkName"`
-	Status        int     `json:"status" yaml:"status"`
-	StatusMessage string  `json:"statusMessage" yaml:"statusMessage"`
-	Info          []Info  `json:"info" yaml:"info"`
-	Events        []Event `json:"events" yaml:"events"`
+	CheckName     string  `json:"checkName"`
+	Status        int     `json:"status"`
+	StatusMessage string  `json:"statusMessage"`
+	Info          []Info  `json:"info"`
+	Events        []Event `json:"events"`
 }
 
 // Some of the types below are taken from:

--- a/analysis.go
+++ b/analysis.go
@@ -126,11 +126,10 @@ func CheckProjectTask(project string, results chan<- CheckResults, JSONResourceF
 // A getProjectCheckFactory generates tasks to diagnose system conditions.
 type getProjectCheckFactory func() []CheckTask
 
-// CheckResults Stores the result of a check in a scope which can a specfic
-// project or platform-wide.
+// CheckResults stores the results of a check and the project in which the
+// checks were applied. For cluster-scoped checks, Project is the empty string.
 type CheckResults struct {
-	Scope   string `json:"scope"`
-	Name    string `json:"name,omitempty"`
+	Project string
 	Results []Result
 }
 
@@ -139,7 +138,7 @@ type CheckResults struct {
 // combined into a single JSON object and returned.
 func checkProjectTask(checkFactory getProjectCheckFactory, JSONResourceFactory DumpedJSONResourceFactory, project string, results chan<- CheckResults) Task {
 	return func() error {
-		result := CheckResults{Scope: "project", Name: project, Results: []Result{}}
+		result := CheckResults{Project: project, Results: []Result{}}
 		checks := checkFactory()
 
 		var errors errorList

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -201,9 +201,6 @@ func TestCheckDeployConfigsReplicasNotZero(t *testing.T) {
 	if res.Status != analysisErrorDiscoveredByAnalysis {
 		t.Fatal("res.Status expected:", analysisErrorDiscoveredByAnalysis, "got:", res.Status)
 	}
-	if res.Info[0].Count != 1 {
-		t.Fatal("res.Info[0].Count expected 1, got:" + string(res.Info[0].Count))
-	}
 
 	res, err = CheckDeployConfigsReplicasNotZero(mockJSONResourceErrorFactory)
 	if err == nil {
@@ -304,9 +301,6 @@ func TestCheckForWaitingPods(t *testing.T) {
 	}
 	if res.Status != analysisErrorDiscoveredByAnalysis {
 		t.Fatal("res.Status expected:", analysisErrorDiscoveredByAnalysis, " got:", res.Status)
-	}
-	if res.Info[0].Count != 1 {
-		t.Fatal("res.Info[0].Count expected 1, got:" + string(res.Info[0].Count))
 	}
 
 	res, err = CheckForWaitingPods(MockPodsWithoutWaitingPod)

--- a/analysis_test.go
+++ b/analysis_test.go
@@ -18,18 +18,18 @@ func mockJSONResourceFactory(p string, d interface{}) error {
 	return nil
 }
 
-func mockTestOne(loader DumpedJSONResourceFactory) (Result, error) {
-	result := Result{StatusMessage: "Called mockTestOne"}
+func mockTestOne(loader DumpedJSONResourceFactory) (CheckResult, error) {
+	result := CheckResult{Message: "Called mockTestOne"}
 	return result, nil
 }
 
-func mockTestTwo(loader DumpedJSONResourceFactory) (Result, error) {
-	result := Result{StatusMessage: "Called mockTestTwo"}
+func mockTestTwo(loader DumpedJSONResourceFactory) (CheckResult, error) {
+	result := CheckResult{Message: "Called mockTestTwo"}
 	return result, errors.New("FAIL")
 }
 
 func TestCheckTasksWithFail(t *testing.T) {
-	results := make(chan CheckResults, 1)
+	results := make(chan AnalysisResult, 1)
 	defer close(results)
 	task := checkProjectTask(mockCheckFactoryOnePassOneFail, mockJSONResourceFactory, "MockProject", results)
 
@@ -40,13 +40,13 @@ func TestCheckTasksWithFail(t *testing.T) {
 	}
 
 	result := <-results
-	if (len(result.Results)) != 2 {
-		t.Fatal("Expected 2 check results, got: " + string(len(result.Results)))
+	if len(result.Projects[0].Results) != 2 {
+		t.Fatal("Expected 2 check results, got: " + string(len(result.Projects[0].Results)))
 	}
 }
 
 func TestCheckTasksWithPass(t *testing.T) {
-	results := make(chan CheckResults, 1)
+	results := make(chan AnalysisResult, 1)
 	defer close(results)
 	task := checkProjectTask(mockCheckFactoryOnePass, mockJSONResourceFactory, "MockProject", results)
 
@@ -57,8 +57,8 @@ func TestCheckTasksWithPass(t *testing.T) {
 	}
 
 	result := <-results
-	if (len(result.Results)) != 1 {
-		t.Fatal("Expected 1 check results, got: " + string(len(result.Results)))
+	if len(result.Projects[0].Results) != 1 {
+		t.Fatal("Expected 1 check results, got: " + string(len(result.Projects[0].Results)))
 	}
 }
 
@@ -123,8 +123,8 @@ func TestCheckEventLogForErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != analysisErrorDiscoveredByAnalysis {
-		t.Fatal("res.Status expected:", analysisErrorDiscoveredByAnalysis, "got:", res.Status)
+	if res.Ok {
+		t.Fatalf("res.Ok = %v, want %v", res.Ok, false)
 	}
 	if len(res.Events) != 1 {
 		t.Fatal("len(res.Events) expected: 1, got:", len(res.Events))
@@ -143,8 +143,8 @@ func TestCheckEventLogForErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("CheckEventLogForErrors(mockJSONResourceErrorFactory) expected error, got none")
 	}
-	if res.Status != analysisErrorReadingDumpedResource {
-		t.Fatal("res.Status expected:", analysisErrorReadingDumpedResource, "got:", res.Status)
+	if res.Ok {
+		t.Fatalf("res.Ok = %v, want %v", res.Ok, false)
 	}
 }
 
@@ -198,16 +198,16 @@ func TestCheckDeployConfigsReplicasNotZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != analysisErrorDiscoveredByAnalysis {
-		t.Fatal("res.Status expected:", analysisErrorDiscoveredByAnalysis, "got:", res.Status)
+	if res.Ok {
+		t.Fatalf("res.Ok = %v, want %v", res.Ok, false)
 	}
 
 	res, err = CheckDeployConfigsReplicasNotZero(mockJSONResourceErrorFactory)
 	if err == nil {
 		t.Fatal("CheckDeployConfigsReplicasNotZero(mockJSONResourceErrorFactory) expected error, got none")
 	}
-	if res.Status != analysisErrorReadingDumpedResource {
-		t.Fatal("res.Status expected", analysisErrorReadingDumpedResource, "got:", res.Status)
+	if res.Ok {
+		t.Fatalf("res.Ok = %v, want %v", res.Ok, false)
 	}
 }
 
@@ -299,16 +299,16 @@ func TestCheckForWaitingPods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != analysisErrorDiscoveredByAnalysis {
-		t.Fatal("res.Status expected:", analysisErrorDiscoveredByAnalysis, " got:", res.Status)
+	if res.Ok {
+		t.Fatalf("res.Ok = %v, want %v", res.Ok, false)
 	}
 
 	res, err = CheckForWaitingPods(MockPodsWithoutWaitingPod)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != analysisErrorNotDiscovered {
-		t.Fatal("res.Status expected:", analysisErrorNotDiscovered, "got:", res.Status)
+	if !res.Ok {
+		t.Fatalf("res.Ok = %v, want %v", res.Ok, true)
 	}
 	if len(res.Info) != 0 {
 		t.Fatal("len(res.Info) expected 0, got:" + string(len(res.Info)))
@@ -318,8 +318,8 @@ func TestCheckForWaitingPods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.Status != analysisErrorNotDiscovered {
-		t.Fatal("res.Status expected:", analysisErrorNotDiscovered, "got:", res.Status)
+	if !res.Ok {
+		t.Fatalf("res.Ok = %v, want %v", res.Ok, true)
 	}
 	if len(res.Info) != 0 {
 		t.Fatal("len(res.Info) expected 0, got:" + string(len(res.Info)))
@@ -329,7 +329,7 @@ func TestCheckForWaitingPods(t *testing.T) {
 	if err == nil {
 		t.Fatal("CheckDeployConfigsReplicasNotZero(mockJSONResourceErrorFactory) expected error, got none")
 	}
-	if res.Status != analysisErrorReadingDumpedResource {
-		t.Fatal("res.Status expected ", analysisErrorReadingDumpedResource, "got:", res.Status)
+	if res.Ok {
+		t.Fatalf("res.Ok = %v, want %v", res.Ok, false)
 	}
 }

--- a/output_results.go
+++ b/output_results.go
@@ -8,19 +8,18 @@ import (
 
 // RunOutputTask will read in the analysis.json file and output
 // any useful information to o or any errors to e.
-func RunOutputTask(o io.Writer, e io.Writer, analysisResults AnalysisResults) {
-	for _, projects := range analysisResults {
-		for project, results := range projects {
-			for _, result := range results {
-				if result.Status != 0 {
-					fmt.Fprintf(o, "Potential issue discovered in %s: %s\n", project, result.CheckName)
-					fmt.Fprintf(o, "  Details:\n")
-					for _, info := range result.Info {
-						fmt.Fprintf(o, "    %s\n", strings.Replace(strings.TrimSpace(info.Message), "\n", "\n    ", -1))
-					}
-					for _, event := range result.Events {
-						fmt.Fprintf(o, "    %s\n", strings.Replace(strings.TrimSpace(event.Message), "\n", "\n    ", -1))
-					}
+func RunOutputTask(o io.Writer, e io.Writer, analysisResult AnalysisResult) {
+	// TODO: handle analysisResult.Platform.
+	for _, projectResult := range analysisResult.Projects {
+		for _, checkResult := range projectResult.Results {
+			if !checkResult.Ok {
+				fmt.Fprintf(o, "Potential issue discovered in project %s: %s\n", projectResult.Project, checkResult.CheckName)
+				fmt.Fprintf(o, "  Details:\n")
+				for _, info := range checkResult.Info {
+					fmt.Fprintf(o, "    %s\n", strings.Replace(strings.TrimSpace(info.Message), "\n", "\n    ", -1))
+				}
+				for _, event := range checkResult.Events {
+					fmt.Fprintf(o, "    %s\n", strings.Replace(strings.TrimSpace(event.Message), "\n", "\n    ", -1))
 				}
 			}
 		}

--- a/output_results_test.go
+++ b/output_results_test.go
@@ -83,7 +83,9 @@ func TestRunOutputTaskNoErrors(t *testing.T) {
 	o := bytes.NewBuffer([]byte{})
 	e := bytes.NewBuffer([]byte{})
 	analysisResults := AnalysisResults{}
-	mockAnalysisNoErrors("", &analysisResults)
+	if err := mockAnalysisNoErrors("", &analysisResults); err != nil {
+		t.Fatal(err)
+	}
 	RunOutputTask(o, e, analysisResults)
 
 	if got := len(o.Bytes()); got > 0 {
@@ -98,7 +100,9 @@ func TestRunOutputTaskFoundErrors(t *testing.T) {
 	o := bytes.NewBuffer([]byte{})
 	e := bytes.NewBuffer([]byte{})
 	analysisResults := AnalysisResults{}
-	mockAnalysisErrors("", &analysisResults)
+	if err := mockAnalysisErrors("", &analysisResults); err != nil {
+		t.Fatal(err)
+	}
 	RunOutputTask(o, e, analysisResults)
 
 	if !strings.Contains(string(o.Bytes()), "rhmap-core") {

--- a/tasks.go
+++ b/tasks.go
@@ -170,9 +170,9 @@ func RunAllAnalysisTasks(runner Runner, path string, workers int) AnalysisResult
 		}
 
 		for result := range checkResults {
-			if result.Scope == "project" {
-				analysisResults["projects"][result.Name] = result.Results
-			} else if result.Scope == "platform" {
+			if result.Project != "" {
+				analysisResults["projects"][result.Project] = result.Results
+			} else {
 				analysisResults["platform"]["platform"] = result.Results
 			}
 

--- a/tasks.go
+++ b/tasks.go
@@ -135,9 +135,9 @@ func GetAllDumpTasks(runner Runner, basepath string) <-chan Task {
 }
 
 // RunAllAnalysisTasks runs all tasks known to the analysis tool using concurrent workers.
-func RunAllAnalysisTasks(runner Runner, path string, workers int) AnalysisResults {
-	checkResults := make(chan CheckResults)
-	tasks := GetAllAnalysisTasks(runner, path, checkResults)
+func RunAllAnalysisTasks(runner Runner, path string, workers int) AnalysisResult {
+	analysisResults := make(chan AnalysisResult)
+	tasks := GetAllAnalysisTasks(runner, path, analysisResults)
 	results := make(chan error)
 
 	// Start worker goroutines to run tasks concurrently.
@@ -156,9 +156,7 @@ func RunAllAnalysisTasks(runner Runner, path string, workers int) AnalysisResult
 	// the analysis.json file
 	var writeWait sync.WaitGroup
 	writeWait.Add(1)
-	analysisResults := AnalysisResults{}
-	analysisResults["projects"] = map[string][]Result{}
-	analysisResults["platform"] = map[string][]Result{}
+	var analysisResult AnalysisResult
 
 	go func() {
 		defer writeWait.Done()
@@ -169,14 +167,11 @@ func RunAllAnalysisTasks(runner Runner, path string, workers int) AnalysisResult
 			return
 		}
 
-		for result := range checkResults {
-			if result.Project != "" {
-				analysisResults["projects"][result.Project] = result.Results
-			} else {
-				analysisResults["platform"]["platform"] = result.Results
-			}
+		for result := range analysisResults {
+			analysisResult.Platform = append(analysisResult.Platform, result.Platform...)
+			analysisResult.Projects = append(analysisResult.Projects, result.Projects...)
 
-			output, err := json.MarshalIndent(analysisResults, "", "    ")
+			output, err := json.MarshalIndent(analysisResult, "", "    ")
 			if err != nil {
 				results <- err
 			}
@@ -188,7 +183,7 @@ func RunAllAnalysisTasks(runner Runner, path string, workers int) AnalysisResult
 	// communicate that no more results will be sent.
 	go func() {
 		wg.Wait()
-		close(checkResults)
+		close(analysisResults)
 		close(results)
 	}()
 
@@ -205,14 +200,14 @@ func RunAllAnalysisTasks(runner Runner, path string, workers int) AnalysisResult
 	}
 	fmt.Fprintln(os.Stderr)
 	writeWait.Wait()
-	return analysisResults
+	return analysisResult
 }
 
 // GetAllAnalysisTasks returns a channel of all the analysis tasks known to the dump tool. It returns
 // immediately and sends tasks to the channel in a separate goroutine. The channel is closed after
 // all tasks are sent.
 // FIXME: GetAllAnalysisTasks should not need to know about basepath.
-func GetAllAnalysisTasks(runner Runner, basepath string, results chan<- CheckResults) <-chan Task {
+func GetAllAnalysisTasks(runner Runner, basepath string, results chan<- AnalysisResult) <-chan Task {
 	tasks := make(chan Task)
 	go func() {
 		defer close(tasks)


### PR DESCRIPTION
This is an attempt to simplify the code for analysis tasks, and have a single interpretation for a "task", so that we could reuse the "task runner" and have a common way to (in the near future) filter out errors that we want to log in the dump.log file, but not show to the user in stdout.

Update: this mostly reviews the type definitons used in `analysis.go`, removing the need to remap results into a map before dump, and slightly changing the format of `analysis.json`.