### PR TITLE
Do not show some errors in stdout

### DIFF
--- a/definitions.go
+++ b/definitions.go
@@ -39,6 +39,6 @@ func ResourceDefinition(r Runner, project, resource string) Task {
 		tree = append(tree, "definitions", fname)
 
 		path := filepath.Join(tree...)
-		return r.Run(cmd, path)
+		return MarkErrorAsIgnorable(r.Run(cmd, path))
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -18,3 +18,40 @@ func (e errorList) Error() string {
 	}
 	return "multiple errors:\n" + strings.Join(msgs, "\n")
 }
+
+// IgnorableError is an error that has an extra method to tell whether it should
+// be ignored. Ignored errors may be omitted from standard program output.
+type IgnorableError interface {
+	error
+	Ignore() bool // Is the error a timeout?
+}
+
+// ignoredError implements IgnorableError, always returning true.
+type ignoredError struct {
+	err error
+}
+
+func (e *ignoredError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+// Ignore implements IgnorableError.
+func (e *ignoredError) Ignore() bool {
+	return true
+}
+
+// Assert that ignoredError implements the IgnorableError interface.
+var _ IgnorableError = (*ignoredError)(nil)
+
+// MarkErrorAsIgnorable marks the original error as ignored if non-nil.
+func MarkErrorAsIgnorable(err error) error {
+	if err == nil {
+		// Keeps nil errors nil, to avoid the confusion of having a
+		// non-nil type and a nil value in an interface value.
+		return nil
+	}
+	return &ignoredError{err}
+}

--- a/logs.go
+++ b/logs.go
@@ -121,6 +121,6 @@ func ocLogs(r Runner, resource LoggableResource, maxLines int, extraArgs []strin
 			filename += "_" + resource.Container
 		}
 		path := filepath.Join("projects", resource.Project, what, filename+".logs")
-		return r.Run(cmd, path)
+		return MarkErrorAsIgnorable(r.Run(cmd, path))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func main() {
 	runner := NewDumpRunner(basePath)
 
 	log.Print("Running dump and analyse tasks...")
-	RunAllDumpTasks(runner, basePath, *concurrentTasks)
+	RunAllDumpTasks(runner, basePath, *concurrentTasks, fileOnlyLogger)
 	analysisResults := RunAllAnalysisTasks(runner, basePath, *concurrentTasks)
 
 	delta := time.Since(start)

--- a/millicore.go
+++ b/millicore.go
@@ -28,6 +28,6 @@ func GetMillicoreConfig(r Runner, project, pod string) Task {
 	return func() error {
 		cmd := exec.Command("oc", "-n", project, "exec", pod, "--", "cat", "/etc/feedhenry/cluster-override.properties")
 		path := filepath.Join("projects", project, "millicore", pod+"_cluster-override.properties")
-		return r.Run(cmd, path)
+		return MarkErrorAsIgnorable(r.Run(cmd, path))
 	}
 }

--- a/nagios.go
+++ b/nagios.go
@@ -35,7 +35,7 @@ func GetNagiosStatusData(r Runner, project, pod string) Task {
 		cmd := exec.Command("oc", "-n", project, "exec", pod, "--", "cat", "/var/log/nagios/status.dat")
 		fname := pod + "_status.dat"
 		path := filepath.Join("projects", project, "nagios", fname)
-		return r.Run(cmd, path)
+		return MarkErrorAsIgnorable(r.Run(cmd, path))
 	}
 }
 
@@ -46,7 +46,7 @@ func GetNagiosHistoricalData(r Runner, project, pod string) Task {
 		cmd := exec.Command("oc", "-n", project, "exec", pod, "--", "tar", "-c", "-C", "/var/log/nagios", "archives")
 		fname := pod + "_history.tar"
 		path := filepath.Join("projects", project, "nagios", fname)
-		return r.Run(cmd, path)
+		return MarkErrorAsIgnorable(r.Run(cmd, path))
 	}
 }
 

--- a/ocadm.go
+++ b/ocadm.go
@@ -7,6 +7,6 @@ func GetOcAdmDiagnosticsTask(runner Runner) Task {
 	return func() error {
 		cmd := exec.Command("oc", "adm", "diagnostics")
 		path := "oc_adm_diagnostics"
-		return runner.Run(cmd, path)
+		return MarkErrorAsIgnorable(runner.Run(cmd, path))
 	}
 }

--- a/openshift_metadata.go
+++ b/openshift_metadata.go
@@ -21,7 +21,7 @@ func GetOpenShiftMetadataTasks(tasks chan<- Task, runner Runner, projects []stri
 		tasks <- func() error {
 			cmd := exec.Command("oc", args...)
 			path := filepath.Join("meta", "oc_"+strings.Join(args, "_"))
-			return runner.Run(cmd, path)
+			return MarkErrorAsIgnorable(runner.Run(cmd, path))
 		}
 	}
 	for _, p := range projects {
@@ -29,7 +29,7 @@ func GetOpenShiftMetadataTasks(tasks chan<- Task, runner Runner, projects []stri
 		tasks <- func() error {
 			cmd := exec.Command("oc", "-n", p, "policy", "can-i", "--list")
 			path := filepath.Join("meta", "projects", p, "oc_-n_"+p+"_policy_can-i_--list")
-			return runner.Run(cmd, path)
+			return MarkErrorAsIgnorable(runner.Run(cmd, path))
 		}
 	}
 }


### PR DESCRIPTION
We want a way to log errors to dump.log, while not bothering users with
common errors that do not reflect actual problems.

For instance, it is common that a call to fetch previous logs will fail
to find a previous pod.

Another example are commands that are available in OSE 3.3 but not in
OSE 3.2, and those are executed regardless of the current client version
in a best effort manner.

---

https://issues.jboss.org/browse/RHMAP-9831