### PR TITLE
go vet: usage of t.Fatalf with non-constant format

### DIFF
--- a/millicore_test.go
+++ b/millicore_test.go
@@ -37,13 +37,14 @@ func TestMillicorePodError(t *testing.T) {
 	tasks := make(chan Task, 1)
 	runner := &FakeRunner{}
 
+	want := errors.New("error retrieving pods")
+
 	GetMillicoreConfigTasks(tasks, runner, []string{"project1"}, func(project, resource, substr string) ([]string, error) {
-		return nil, errors.New("error retrieving pods")
+		return nil, want
 	})
 
 	task := <-tasks
-	err := task()
-	if err.Error() != "error retrieving pods" {
-		t.Fatalf("Task(): Want: error retrieving pods, Got: " + err.Error())
+	if err := task(); err != want {
+		t.Fatalf("task() = %v, want %v", err, want)
 	}
 }


### PR DESCRIPTION
This fixes a warning from go vet. Normally we pass a constant string
literal to t.Fatalf.

In this case we can also compare errors directly, instead of comparing
their string representation.