### PR TITLE
Improve CI, allow running locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
- - 1.6.3
+  - 1.6.3
+install:
+  - go get -u github.com/golang/lint/golint
+  - go get -u golang.org/x/tools/cmd/goimports
 script:
-  - test -z "$(gofmt -s -l $(find . -name '*.go'))" || { echo "Code needs to be gofmt'ed"; false; }
-  - go test ./...
+  - make --keep-going ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,24 @@ directory. It is recommended that GOPATH/bin is part of your PATH environment
 variable.
 
 
+## Testing
+
+Pull Requests are automatically tested using [Travis
+CI](https://travis-ci.org/). You can run the same tests locally during development:
+
+```
+make -k ci
+```
+
+That will run several verifications involving code formatting, unit tests, etc.
+The `-k` flag tells `make` to keep running even if one of the verifications
+fail. If you want to to terminate after encountering the first problem, omit
+that flag.
+
+To see what commands are used for testing, look at the output of `make -n ci`.
+Refer to the [Makefile](Makefile) to see how each verification is implemented.
+
+
 ## Releasing
 
 To release a new version:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 ifndef FH_SYSTEM_DUMP_TOOL_VERSION
 FH_SYSTEM_DUMP_TOOL_VERSION := $(shell git describe --tags --abbrev=14)
 endif
@@ -10,3 +12,32 @@ all:
 .PHONY: clean
 clean:
 	@-go clean -i
+
+.PHONY: ci
+ci: check-gofmt check-goimports check-golint vet test test-race
+
+# goimports doesn't support the -s flag to simplify code, therefore we use both
+# goimports and gofmt -s.
+.PHONY: check-gofmt
+check-gofmt:
+	diff <(gofmt -s -d .) <(printf "")
+
+.PHONY: check-goimports
+check-goimports:
+	diff <(goimports -d .) <(printf "")
+
+.PHONY: check-golint
+check-golint:
+	diff <(golint ./...) <(printf "")
+
+.PHONY: vet
+vet:
+	go vet ./...
+
+.PHONY: test
+test:
+	go test -v -cpu=2 ./...
+
+.PHONY: test-race
+test-race:
+	go test -v -cpu=1,2,4 -short -race ./...


### PR DESCRIPTION
- Use goimports in addition to gofmt -s.
- Checks `go vet` for errors.
- Experimentally adds `golint` -- we've discussed adding it before, we
  can give it a shot and disable if it starts to annoy us.
- Run tests an additional time with the -race flag.
- Document how to test code locally.