### PR TITLE
Do not print error from GetPodContainers to user

### DIFF
--- a/logs.go
+++ b/logs.go
@@ -84,7 +84,8 @@ func GetPodContainers(runner Runner, project, name string) ([]string, error) {
 	if err := runner.Run(cmd, filepath.Join("projects", project, "pods", name, "container-names")); err != nil {
 		return nil, err
 	}
-	return readSpaceSeparated(&b)
+	names, err := readSpaceSeparated(&b)
+	return names, MarkErrorAsIgnorable(err)
 }
 
 // FetchLogs is a task factory for tasks that fetch the logs of a


### PR DESCRIPTION
Log the error to the dump.log file, but do not bother the user, as she
can't act upon that error.

Completes the work from https://github.com/feedhenry/fh-system-dump-tool/pull/50.