### PR TITLE
Add make target to build a release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/dist/
 /reports/
 /rhmap-dumps/
 .idea

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,7 @@ To release a new version:
 * Tag a new version, e.g., `v0.1.0`
 * Create a new __Release__ from the [releases](https://github.com/feedhenry/fh-system-dump-tool/releases) page
 * Add some info about the release
-* Build a release binary using `make`
-* Upload the built binary
-* Publish it
+* Run `git fetch --tags` and make sure you have the tag you've just created
+* Build a release binary using `make release` (requires Docker)
+* Upload the built archive in the `dist/` directory
+* Publish the release

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ FH_SYSTEM_DUMP_TOOL_VERSION := $(shell git describe --tags --abbrev=14)
 endif
 LDFLAGS := -X main.Version=$(FH_SYSTEM_DUMP_TOOL_VERSION)
 
+IMPORT_PATH := github.com/feedhenry/fh-system-dump-tool
+GO_DOCKER_IMAGE := golang:1.8
+
 .PHONY: all
 all:
 	@go install -v -ldflags '$(LDFLAGS)'
@@ -41,3 +44,15 @@ test:
 .PHONY: test-race
 test-race:
 	go test -v -cpu=1,2,4 -short -race ./...
+
+.PHONY: release
+release:
+	docker run --rm \
+		-v "$(PWD):/go/src/$(IMPORT_PATH)" \
+		-w "/go/src/$(IMPORT_PATH)" \
+		"$(GO_DOCKER_IMAGE)" make dist
+
+.PHONY: dist
+dist: all
+	mkdir -p dist
+	tar -C "/go/bin" -czf "dist/fh-system-dump-tool-$(FH_SYSTEM_DUMP_TOOL_VERSION)-linux-amd64.tar.gz" "fh-system-dump-tool"


### PR DESCRIPTION
This is what I used to generate https://github.com/feedhenry/fh-system-dump-tool/releases/tag/v1.0.0.
